### PR TITLE
DD-338 A.1 — flip home-assistant granularity on 4 read tools

### DIFF
--- a/plugins/tools/home-assistant-blade-mcp.json
+++ b/plugins/tools/home-assistant-blade-mcp.json
@@ -3,7 +3,7 @@
   "title": "Home Assistant",
   "description": "Home Assistant operations \u2014 entities, state, history, device control, automations, energy, multi-site management",
   "tagline": "Multi-site Home Assistant control with write gating",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": "groupthink-dev",
   "license": "MIT",
   "icon": "/icons/home-assistant-blade-mcp.svg",
@@ -112,10 +112,10 @@
       "description": "List all devices with manufacturer, model, area assignment.",
       "risk_class": "read_only",
       "granularity": {
-        "scope_filtering": "client-side",
+        "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "unsorted",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -123,10 +123,10 @@
       "description": "List entities, optionally filtered by domain, area, or label.",
       "risk_class": "read_only",
       "granularity": {
-        "scope_filtering": "client-side",
+        "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "unsorted",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -203,7 +203,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "unsorted",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -236,7 +236,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Flip `scope_filtering: client-side → server-side` on `ha_devices` + `ha_entities` (was an honest client-side declaration before this phase; HA-as-one-scope verdict is now computed server-side).
- Flip `audit_surface: minimal → structured` on `ha_devices`, `ha_entities`, `ha_states_by_domain`, `ha_statistics` (now emit JSON-tail `_meta` envelope per DD-338 amendment).
- Bump catalog `version` 0.1.1 → 0.2.0.

## Spec
`atlas/utilities/agent-harness/specs/2026-05-21-dd-338-a1-home-assistant.md`

## Blade-mcp PR
Groupthink-dev/home-assistant-blade-mcp#1

## Test plan
- [x] `node scripts/build-catalog.js` green (59 plugins + 11 packs)
- [x] `node scripts/validate-plugin.js plugins/tools/home-assistant-blade-mcp.json` green (schema-conformant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)