### PR TITLE
DD-338 A.1 — flip mastodon granularity on 4 read tools

### DIFF
--- a/plugins/tools/mastodon-blade-mcp.json
+++ b/plugins/tools/mastodon-blade-mcp.json
@@ -42,13 +42,13 @@
     },
     {
       "name": "mastodon_timeline_home",
-      "description": "Home timeline \u2014 accounts you follow. Cursor pagination.",
+      "description": "Home timeline \u2014 accounts you follow. Cursor pagination. Accepts scope=public|personal|family|work mapped to Mastodon lists via MASTODON_*_LIST_ID env vars.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "unstable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -119,13 +119,13 @@
     },
     {
       "name": "mastodon_search",
-      "description": "Search statuses, accounts, and hashtags.",
+      "description": "Search statuses, accounts, and hashtags. Accepts scope=public|personal|family|work to restrict status results to accounts in the scope's list.",
       "risk_class": "read_only",
       "granularity": {
-        "scope_filtering": "client-side",
+        "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "unstable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -141,13 +141,13 @@
     },
     {
       "name": "mastodon_account_statuses",
-      "description": "Statuses authored by an account.",
+      "description": "Statuses authored by an account. Accepts scope=public|personal|family|work as a membership precondition — refuses if account_id is outside the scope's list.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "unstable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -185,13 +185,13 @@
     },
     {
       "name": "mastodon_notifications",
-      "description": "Recent notifications \u2014 mentions, follows, boosts, favourites.",
+      "description": "Recent notifications \u2014 mentions, follows, boosts, favourites. Accepts scope=public|personal|family|work to filter to actors in the scope's list.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "unstable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -532,6 +532,21 @@
       "name": "MASTODON_WRITE_ENABLED",
       "description": "Enable write operations (posting, favouriting, following)",
       "default": "false"
+    },
+    {
+      "name": "MASTODON_PERSONAL_LIST_ID",
+      "description": "Mastodon list ID mapped to scope=personal. Per-instance form: MASTODON_PERSONAL_LIST_ID_<INSTANCE>. Leave unset → scope=personal degrades to passthrough.",
+      "default": ""
+    },
+    {
+      "name": "MASTODON_FAMILY_LIST_ID",
+      "description": "Mastodon list ID mapped to scope=family. Per-instance form: MASTODON_FAMILY_LIST_ID_<INSTANCE>.",
+      "default": ""
+    },
+    {
+      "name": "MASTODON_WORK_LIST_ID",
+      "description": "Mastodon list ID mapped to scope=work. Per-instance form: MASTODON_WORK_LIST_ID_<INSTANCE>.",
+      "default": ""
     }
   ],
   "setup": {


### PR DESCRIPTION
## Summary

Catalog companion to https://github.com/Groupthink-dev/mastodon-blade-mcp/pull/1 (DD-338 A.1 hardening on the top-4 mastodon read tools).

Changes to `plugins/tools/mastodon-blade-mcp.json`:

- 4 tools (`mastodon_timeline_home`, `mastodon_search`, `mastodon_notifications`, `mastodon_account_statuses`): flip `granularity.audit_surface: minimal → structured`.
- `mastodon_search`: flip `granularity.scope_filtering: client-side → server-side` (the impl PR adds the required `scope=` arg).
- 3 other tools were already declared `server-side` but had no scope arg backing — this catalog change is now honest (impl PR adds the arg).
- 3 new env entries appended: `MASTODON_PERSONAL_LIST_ID`, `MASTODON_FAMILY_LIST_ID`, `MASTODON_WORK_LIST_ID` (each documents per-instance suffix form).
- Tool descriptions extended on all 4 with the `scope=` vocabulary + semantics.

`granularity.deterministic_ordering` left untouched — promotion to `stable` deferred to DD-338 Phase B.1 (sort-before-return cheap path).

## Test plan

- [x] `node scripts/build-catalog.js` — green (`Built catalog: 59 plugins + 11 packs = 70 entries, 37 services`).
- [x] `node scripts/validate-plugin.js plugins/tools/mastodon-blade-mcp.json` — green.
- [ ] Architect HITL — confirm `audit_surface: structured` is the correct declaration for the new `_meta` envelope (the assembler-side consumer lands separately via DD-333 Phase B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)