### PR TITLE
DD-338 A.1 — flip tailscale granularity on 4 read tools (honest client-side)

### DIFF
--- a/plugins/tools/tailscale-blade-mcp.json
+++ b/plugins/tools/tailscale-blade-mcp.json
@@ -76,24 +76,24 @@
     },
     {
       "name": "ts_devices",
-      "description": "List devices — hostname, OS, IP, online/offline, key expiry, tags, update status.",
+      "description": "List devices — hostname, OS, IP, online/offline, key expiry, tags, update status. DD-278 scope-tag filter applied client-side.",
       "risk_class": "read_only",
       "granularity": {
-        "scope_filtering": "none",
+        "scope_filtering": "client-side",
         "field_projection": "none",
         "deterministic_ordering": "unstable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
       "name": "ts_device",
-      "description": "Full detail for a single device — addresses, OS, client version, key status, tags, user.",
+      "description": "Full detail for a single device — addresses, OS, client version, key status, tags, user. Track 3 _meta envelope on single-record fetch.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -142,13 +142,13 @@
     },
     {
       "name": "ts_keys",
-      "description": "List auth keys — ID, description, reusable/ephemeral/preauth flags, tags, expiry.",
+      "description": "List auth keys — ID, description, reusable/ephemeral/preauth flags, tags, expiry. DD-278 scope-tag filter applied client-side over capabilities.devices.create.tags.",
       "risk_class": "read_only",
       "granularity": {
-        "scope_filtering": "none",
+        "scope_filtering": "client-side",
         "field_projection": "none",
         "deterministic_ordering": "unstable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -175,13 +175,13 @@
     },
     {
       "name": "ts_audit_log",
-      "description": "Configuration audit log — who changed what, when. Server-side count parameter for bound result set.",
+      "description": "Configuration audit log — who changed what, when. Server-side count parameter for bound result set. DD-278 scope filter applied client-side via secondary device-tag fetch (Tailscale REST API has no server-side actor/target tag filter primitive).",
       "risk_class": "read_only",
       "granularity": {
-        "scope_filtering": "server-side",
+        "scope_filtering": "client-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {


### PR DESCRIPTION
## Summary

Catalog companion for DD-338 Phase A.1 implementation in Groupthink-dev/tailscale-blade-mcp#1.

- `ts_devices`: `scope_filtering` `none` → `client-side`; `audit_surface` `minimal` → `structured`
- `ts_device`: `audit_surface` `minimal` → `structured` (single-record fetch — `scope_filtering` stays `server-side` because `device_id` IS the filter axis)
- `ts_keys`: `scope_filtering` `none` → `client-side`; `audit_surface` `minimal` → `structured`
- `ts_audit_log`: `scope_filtering` `server-side` → **`client-side`** (corrects pre-existing dishonest declaration — `count=` is server-side but the new `scope=` actor/target filter is post-hoc); `audit_surface` `minimal` → `structured`

## Honesty contract

`scope_filtering: client-side` is the **honest** declaration. Tailscale REST API v2 has no server-side tag filter primitive on `/tailnet/-/devices`, `/tailnet/-/keys`, or `/tailnet/-/logging/configuration`. Claiming `server-side` would silently degrade DD-287 ContextPacket audit-trail accuracy.

Per DD-333 § verdict logic, `client-side` declarations at `evidentiary` dispatch level still refuse — contract behaviour, not defect.

Pairs with Groupthink-dev/tailscale-blade-mcp#1.

## Test plan

- [x] `node scripts/build-catalog.js` — catalog builds (59 plugins + 11 packs)
- [x] `npm test` — 143 passed, 14 skipped (pre-existing skips)
- [x] Schema enum check: `scope_filtering: client-side` accepted by `catalog-entry.schema.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)