### PR TITLE
DD-338 A.1 — flip syncthing granularity on 3 read tools

### DIFF
--- a/plugins/tools/syncthing-blade-mcp.json
+++ b/plugins/tools/syncthing-blade-mcp.json
@@ -4,7 +4,7 @@
   "title": "Syncthing",
   "description": "Syncthing replication management MCP \u2014 multi-instance, token-efficient output, safe disk-space reclamation. Read and control access to Syncthing's REST API with a focus on replication awareness: knowing which folders are fully replicated across devices so you can confidently reclaim local disk space.",
   "tagline": "Mesh file sync with replication-aware disk reclamation",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "groupthink-dev",
   "license": "MIT",
   "icon": "/icons/syncthing-blade-mcp.svg",
@@ -28,13 +28,13 @@
   "tools": [
     {
       "name": "syncthing_list_devices",
-      "description": "List all configured Syncthing devices with online/offline status.",
+      "description": "List all configured Syncthing devices with online/offline status. (DD-278 `scope=` tag accepted; folder set resolved via `SYNCTHING_<SCOPE>_FOLDERS` env var; canonical sort by deviceID; _meta envelope tail.)",
       "risk_class": "read_only",
       "granularity": {
-        "scope_filtering": "none",
+        "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -182,13 +182,13 @@
     },
     {
       "name": "syncthing_folder_status",
-      "description": "Current sync state, error count, and need bytes for a folder.",
+      "description": "Current sync state, error count, and need bytes for a folder. (DD-278 `scope=` tag accepted as folder-membership precondition; _meta envelope tail.)",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -204,13 +204,13 @@
     },
     {
       "name": "syncthing_replication_report",
-      "description": "Cross-device replication summary for a folder.",
+      "description": "Cross-device replication summary for a folder. (DD-278 `scope=` tag accepted; folder set resolved via `SYNCTHING_<SCOPE>_FOLDERS` env var; sort tie-broken by folder id; _meta envelope tail.)",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {


### PR DESCRIPTION
## Summary

Catalog companion to https://github.com/Groupthink-dev/syncthing-blade-mcp/pull/2.

Flips honest granularity declarations on the 3 syncthing read tools that ship the scope= arg + canonical sort + _meta envelope hardening in the paired blade-mcp PR.

### Per-tool changes

| Tool | scope_filtering | audit_surface | deterministic_ordering |
|---|---|---|---|
| `syncthing_list_devices` | none → **server-side** | minimal → **structured** | stable (unchanged; sort is now canonical) |
| `syncthing_folder_status` | server-side (kept; was over-declared) | minimal → **structured** | stable (unchanged) |
| `syncthing_replication_report` | server-side (kept; was over-declared) | minimal → **structured** | stable (unchanged; sort now has id tie-breaker) |

`syncthing_folder_status` + `syncthing_replication_report` previously declared `scope_filtering: server-side` without an actual scope arg backing — the paired blade-mcp PR adds the arg so the declarations are now honest. This closes the pre-existing drift.

### Other changes
- Catalog `version: 0.4.0 → 0.5.0` (mirrors blade-mcp package version bump)
- Tool descriptions extended with scope/_meta cue

### Companion PR
https://github.com/Groupthink-dev/syncthing-blade-mcp/pull/2

## Test plan

- [x] `node scripts/build-catalog.js` → 70 entries / 37 services (clean build)
- [x] JSON parses cleanly (`python3 -c "json.load(...)"` 38 tools)
- [x] No other catalog entries touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)