### PR TITLE
DD-338 B.1.a — flip single-record-return deterministic_ordering to stable

### DIFF
--- a/plugins/tools/gmail-blade-mcp.json
+++ b/plugins/tools/gmail-blade-mcp.json
@@ -124,7 +124,7 @@
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -135,7 +135,7 @@
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -278,7 +278,7 @@
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -289,7 +289,7 @@
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     }

--- a/plugins/tools/google-home-blade-mcp.json
+++ b/plugins/tools/google-home-blade-mcp.json
@@ -69,7 +69,7 @@
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -179,7 +179,7 @@
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },

--- a/plugins/tools/home-assistant-blade-mcp.json
+++ b/plugins/tools/home-assistant-blade-mcp.json
@@ -70,7 +70,7 @@
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -81,7 +81,7 @@
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -422,7 +422,7 @@
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },

--- a/plugins/tools/mastodon-blade-mcp.json
+++ b/plugins/tools/mastodon-blade-mcp.json
@@ -25,7 +25,7 @@
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -36,7 +36,7 @@
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -141,7 +141,7 @@
     },
     {
       "name": "mastodon_account_statuses",
-      "description": "Statuses authored by an account. Accepts scope=public|personal|family|work as a membership precondition — refuses if account_id is outside the scope's list.",
+      "description": "Statuses authored by an account. Accepts scope=public|personal|family|work as a membership precondition \u2014 refuses if account_id is outside the scope's list.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
@@ -535,7 +535,7 @@
     },
     {
       "name": "MASTODON_PERSONAL_LIST_ID",
-      "description": "Mastodon list ID mapped to scope=personal. Per-instance form: MASTODON_PERSONAL_LIST_ID_<INSTANCE>. Leave unset → scope=personal degrades to passthrough.",
+      "description": "Mastodon list ID mapped to scope=personal. Per-instance form: MASTODON_PERSONAL_LIST_ID_<INSTANCE>. Leave unset \u2192 scope=personal degrades to passthrough.",
       "default": ""
     },
     {

--- a/plugins/tools/syncthing-blade-mcp.json
+++ b/plugins/tools/syncthing-blade-mcp.json
@@ -352,7 +352,7 @@
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -440,7 +440,7 @@
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     }

--- a/plugins/tools/tailscale-blade-mcp.json
+++ b/plugins/tools/tailscale-blade-mcp.json
@@ -70,7 +70,7 @@
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },


### PR DESCRIPTION
## Summary

- 14 first-party tools across 6 blade-mcp catalog entries flipped from `deterministic_ordering: unstable` → `stable`
- All 14 are single-record returns (one health object / one image / one classification / one summary) — single-record IS stable by definition (only one possible ordering of one element)
- Catalog-only; no blade-mcp code changes

## Tools flipped

| Blade | Tools |
|---|---|
| home-assistant | `ha_info`, `ha_config`, `ha_camera_snapshot` |
| mastodon | `mastodon_info`, `mastodon_verify` |
| syncthing | `syncthing_system_status`, `syncthing_health_summary` |
| tailscale | `ts_info` |
| google-home | `ghome_info`, `ghome_camera_image` |
| gmail | `gmail_info`, `gmail_state`, `gmail_classify`, `gmail_summarise` |

Per [DD-338 implementation plan § Phase B.1.a (architect amendment 2026-05-22)](../../../master-ai/atlas/utilities/agent-harness/decisions/DD-338-implementation-plan.md).

## Honesty rationale

DD-333 Phase E gates on honest declaration, not proceed-shape. The prior `unstable` declaration on single-record returns was over-declared degraded state — a single record has exactly one possible ordering, so byte-identical output order is trivially guaranteed. Flipping to `stable` brings the declaration in line with the contract docs (`docs/granularity.md:65`: "Identical inputs produce byte-identical output order").

`gmail_classify` and `gmail_summarise` are LLM-inference tools — output bytes vary across calls. The `deterministic_ordering` field describes ordering of records in the result set, not content reproducibility — a single-record return has only one ordering regardless of content variance.

## Test plan

- [x] `make test` — 143/143 pass, 0 fail
- [x] `make validate` — all 60+ tool entries schema-clean (exit 0)
- [ ] Architect verifies catalog-build pipeline picks up changes on next dispatch
- [ ] Phase B.1.b dispatched separately (sort-before-return on ~50 multi-record tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)