### PR TITLE
DD-333 Phase F.4 (plugins) — domain_scope schema + AJV gate

### DIFF
--- a/examples/domain-scope-pack/pack-domain-scope-multi-honest.yaml
+++ b/examples/domain-scope-pack/pack-domain-scope-multi-honest.yaml
@@ -1,0 +1,42 @@
+# DD-333 F.4 example — honest multi-domain pack.
+#
+# Demonstrates a pack whose blade tools legitimately span multiple
+# user-declared domains in a single response. The blade's tools[] declare
+# granularity.domain_scope="multi" AND advertise a `scope` argument so the
+# caller can restrict the cross-domain query. The blade is expected to
+# populate _meta.domain_attribution per DD-338 A.2.dom; the assembler
+# partitions per-domain on packet ingest.
+#
+# Reference shape only — see canonical declaration in plugins/tools/.
+pack: "1.0"
+name: domain-scope-multi-honest-pack
+version: 1.0.0
+description: |
+  Reference pack showing honest domain_scope="multi" declarations for tools
+  that legitimately span multiple bound domains. `scope` argument is
+  contractually consistent with `multi`.
+author: stallari
+tier: certified
+skills:
+  - name: cross_account_search
+    description: Search messages across all bound mail accounts.
+    category: inbox
+    services_used:
+      - service: mail
+        tool: search_messages
+# Reference tools[] shape:
+#
+#   tools:
+#     - name: search_messages
+#       arguments:
+#         - name: scope
+#           type: string
+#           description: Optional comma-separated list of account domains.
+#         - name: query
+#           type: string
+#       granularity:
+#         scope_filtering: server-side
+#         field_projection: per-field
+#         deterministic_ordering: stable
+#         audit_surface: structured
+#         domain_scope: multi

--- a/examples/domain-scope-pack/pack-domain-scope-single-honest.yaml
+++ b/examples/domain-scope-pack/pack-domain-scope-single-honest.yaml
@@ -1,0 +1,36 @@
+# DD-333 F.4 example — honest single-domain pack.
+#
+# Demonstrates a pack whose blade tools each declare granularity.domain_scope
+# honestly. Every tool is bound to a single user-declared domain (e.g. one
+# Apple Mail account, one Notes vault). No tool exposes a user-domain-shaped
+# scope argument (no `scope`, `domain`, `domains`, `domainName`, `domain_name`).
+#
+# Reference shape only — this fixture is intentionally minimal; the live
+# catalog tools[] declaration lives in plugins/tools/<plugin>.json. This
+# file documents the authoring pattern for tool authors choosing the
+# `single` declaration.
+pack: "1.0"
+name: domain-scope-single-honest-pack
+version: 1.0.0
+description: |
+  Reference pack showing honest domain_scope="single" declarations across
+  bound-to-one-domain blade tools.
+author: stallari
+tier: certified
+skills:
+  - name: list_inbox_today
+    description: List today's inbox messages from the bound account.
+    category: inbox
+    services_used:
+      - service: mail
+        tool: list_inbox_messages
+# Reference tools[] shape (mirrors plugins/tools/<plugin>.json):
+#
+#   tools:
+#     - name: list_inbox_messages
+#       granularity:
+#         scope_filtering: server-side
+#         field_projection: per-field
+#         deterministic_ordering: stable
+#         audit_surface: structured
+#         domain_scope: single

--- a/examples/domain-scope-pack/pack-domain-scope-single-with-scope-arg-violation.yaml
+++ b/examples/domain-scope-pack/pack-domain-scope-single-with-scope-arg-violation.yaml
@@ -1,0 +1,49 @@
+# DD-333 F.4 example — INCORRECT single-with-scope-arg shape (S-DOM-002 violation).
+#
+# This pack documents a NEGATIVE case: tool author declared
+# granularity.domain_scope="single" but the tool also advertises a `scope`
+# argument with string type. build-catalog.js emits an S-DOM-002 warning
+# because the contract is internally inconsistent — a scope argument that
+# admits multiple domain values contradicts the single-domain contract.
+#
+# Author fix paths:
+#   (a) Change domain_scope to "multi" (and populate _meta.domain_attribution
+#       per A.2.dom) if the tool genuinely spans multiple domains.
+#   (b) Remove the `scope` argument if the tool is genuinely bound to one
+#       domain (caller cannot select a different domain).
+#   (c) If the `scope` argument truly accepts only a single value at a time
+#       (so each call is single-domain even though the arg name resembles
+#       a domain selector), add `// scope-arg-disclaimer: <reason>` to the
+#       tool description to downgrade the finding to info-level.
+#
+# Reference shape only — see negative fixture in
+# schemas/fixtures/catalog-entries/tool-domain-scope-single-with-scope-arg-violation.json.
+pack: "1.0"
+name: domain-scope-single-violation-pack
+version: 1.0.0
+description: |
+  Negative reference pack — illustrates the S-DOM-002 violation shape
+  (domain_scope="single" alongside a `scope` argument with string type).
+author: stallari
+tier: community
+skills:
+  - name: list_legacy_records
+    description: List records using the legacy scope-filtered endpoint.
+    category: catalog
+    services_used:
+      - service: example
+        tool: list_records
+# Reference VIOLATION tools[] shape (do NOT copy verbatim):
+#
+#   tools:
+#     - name: list_records
+#       description: Caller passes scope to filter; legacy contradictory declaration.
+#       arguments:
+#         - name: scope
+#           type: string
+#       granularity:
+#         scope_filtering: server-side
+#         field_projection: per-field
+#         deterministic_ordering: stable
+#         audit_surface: structured
+#         domain_scope: single  # ← Contradicts the scope argument above.

--- a/schemas/catalog-entry.schema.json
+++ b/schemas/catalog-entry.schema.json
@@ -123,6 +123,10 @@
               "audit_surface": {
                 "enum": ["structured", "minimal", "none"],
                 "description": "structured: tool returns a _meta envelope alongside results (matched_total, returned, filtered_by, redactions) the assembler lifts into ContextPacket.provenance. minimal: tool returns only the data payload; assembler records call shape only. none: tool returns opaque data with no introspection."
+              },
+              "domain_scope": {
+                "enum": ["single", "multi", "non-conforming-explicit"],
+                "description": "DD-333 F.4 — 5th granularity dimension declaring whether this tool's result-set originates from a single user-declared domain or from multiple/all domains (cross-DD with DD-341 domain substrate and DD-338 _meta.domain_attribution). single: tool's response covers exactly ONE user-declared domain — either the tool is scoped by upstream binding (e.g. a per-account blade) or the caller's domain selection is honoured server-side. multi: tool's response may legitimately span multiple domains in one call (e.g. cross-account search, cross-domain aggregation) — at A.2.dom the blade must populate _meta.domain_attribution; assembler partitions per-domain on packet ingest. non-conforming-explicit: build-catalog.js derives this for tools listed in non_conformance_rationale.domain_scope_unspecified — author has explicitly acknowledged the tool cannot yet declare domain_scope; assembler treats as worst-case (single-only safe). Optional at F.4 ship; promoted to required at F.4.b after A.2.dom blade backfill. S-DOM-002 lint (severity warning at F.4) flags tools declaring `single` that also expose a user-domain-shaped scope argument — likely indicates the author meant `multi` (scope arg admits multiple domains)."
               }
             }
           }
@@ -165,6 +169,12 @@
           "uniqueItems": true,
           "items": { "type": "string" },
           "description": "Tool names from this entry's tools[].name. Every entry here MUST cross-reference an actual tool name (procedural gate in build-catalog.js + S-MCP-002 in stallari-secops-scanner enforce the cross-field invariant — JSON Schema 2020-12 cannot express it)."
+        },
+        "domain_scope_unspecified": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "type": "string" },
+          "description": "DD-333 F.4 — additive non-conformance escape hatch for the 5th granularity dimension (domain_scope). Optional list of tool names from this entry's tools[].name that legitimately cannot yet declare domain_scope (upstream provider doesn't expose per-domain partitioning, blade pre-dates DD-341 substrate, etc.). build-catalog.js derives `granularity.domain_scope: \"non-conforming-explicit\"` for each listed tool (sister to existing scope_filtering derivation). Cross-field invariant (every entry must cross-reference an actual tools[].name) is enforced procedurally in build-catalog.js. Promoted to mandatory backfill at F.4.b after A.2.dom blade declarations land."
         }
       }
     },

--- a/schemas/fixtures/catalog-entries/tool-domain-scope-bogus-enum.json
+++ b/schemas/fixtures/catalog-entries/tool-domain-scope-bogus-enum.json
@@ -1,0 +1,31 @@
+{
+  "name": "domain-scope-bogus-blade-mcp",
+  "type": "plugin",
+  "description": "DD-333 F.4 fixture — granularity.domain_scope carries an out-of-enum value. AJV reject.",
+  "version": "1.0.0",
+  "author": "stallari",
+  "license": "MIT",
+  "tier": "community",
+  "author_type": "community",
+  "contract": "example-v1",
+  "repository": "https://github.com/Groupthink-dev/domain-scope-bogus-blade-mcp",
+  "install": {
+    "runtime": "uv",
+    "package": "domain-scope-bogus-blade-mcp"
+  },
+  "risk_class": "read_only",
+  "tools": [
+    {
+      "name": "list_records",
+      "description": "List records.",
+      "risk_class": "read_only",
+      "granularity": {
+        "scope_filtering": "server-side",
+        "field_projection": "per-field",
+        "deterministic_ordering": "stable",
+        "audit_surface": "structured",
+        "domain_scope": "magic"
+      }
+    }
+  ]
+}

--- a/schemas/fixtures/catalog-entries/tool-domain-scope-disclaimer.json
+++ b/schemas/fixtures/catalog-entries/tool-domain-scope-disclaimer.json
@@ -1,0 +1,38 @@
+{
+  "name": "domain-scope-disclaimer-blade-mcp",
+  "type": "plugin",
+  "description": "DD-333 F.4 fixture — tool declares domain_scope=\"single\" AND advertises a `scope` argument BUT carries `// scope-arg-disclaimer: <reason>` in description. AJV pass; build-catalog emits S-DOM-002 info-level finding (not warning).",
+  "version": "1.0.0",
+  "author": "stallari",
+  "license": "MIT",
+  "tier": "certified",
+  "author_type": "first-party",
+  "contract": "example-v1",
+  "repository": "https://github.com/Groupthink-dev/domain-scope-disclaimer-blade-mcp",
+  "install": {
+    "runtime": "uv",
+    "package": "domain-scope-disclaimer-blade-mcp"
+  },
+  "risk_class": "read_only",
+  "tools": [
+    {
+      "name": "list_records",
+      "description": "List records. Caller passes scope to select exactly ONE domain at a time. // scope-arg-disclaimer: scope argument accepts only a single value per call; multi-domain calls require N separate invocations.",
+      "risk_class": "read_only",
+      "arguments": [
+        {
+          "name": "scope",
+          "type": "string",
+          "description": "Domain scope filter (single value only)."
+        }
+      ],
+      "granularity": {
+        "scope_filtering": "server-side",
+        "field_projection": "per-field",
+        "deterministic_ordering": "stable",
+        "audit_surface": "structured",
+        "domain_scope": "single"
+      }
+    }
+  ]
+}

--- a/schemas/fixtures/catalog-entries/tool-domain-scope-multi-honest.json
+++ b/schemas/fixtures/catalog-entries/tool-domain-scope-multi-honest.json
@@ -1,0 +1,42 @@
+{
+  "name": "domain-scope-multi-honest-blade-mcp",
+  "type": "plugin",
+  "description": "DD-333 F.4 fixture — tool legitimately declares domain_scope=\"multi\" because results may span multiple user-declared domains. AJV pass; no S-DOM-002 finding (multi is the contract that legitimises a scope argument).",
+  "version": "1.0.0",
+  "author": "stallari",
+  "license": "MIT",
+  "tier": "certified",
+  "author_type": "first-party",
+  "contract": "example-v1",
+  "repository": "https://github.com/Groupthink-dev/domain-scope-multi-honest-blade-mcp",
+  "install": {
+    "runtime": "uv",
+    "package": "domain-scope-multi-honest-blade-mcp"
+  },
+  "risk_class": "read_only",
+  "tools": [
+    {
+      "name": "search_messages",
+      "description": "Search messages across multiple bound accounts. Caller selects subset via scope argument; results carry _meta.domain_attribution per A.2.dom.",
+      "risk_class": "read_only",
+      "arguments": [
+        {
+          "name": "scope",
+          "type": "string",
+          "description": "Optional comma-separated list of account domains to restrict the search to."
+        },
+        {
+          "name": "query",
+          "type": "string"
+        }
+      ],
+      "granularity": {
+        "scope_filtering": "server-side",
+        "field_projection": "per-field",
+        "deterministic_ordering": "stable",
+        "audit_surface": "structured",
+        "domain_scope": "multi"
+      }
+    }
+  ]
+}

--- a/schemas/fixtures/catalog-entries/tool-domain-scope-single-honest.json
+++ b/schemas/fixtures/catalog-entries/tool-domain-scope-single-honest.json
@@ -1,0 +1,31 @@
+{
+  "name": "domain-scope-single-honest-blade-mcp",
+  "type": "plugin",
+  "description": "DD-333 F.4 fixture — single tool honestly declares domain_scope=\"single\" with no user-domain-shaped scope argument. AJV pass; no S-DOM-002 finding.",
+  "version": "1.0.0",
+  "author": "stallari",
+  "license": "MIT",
+  "tier": "certified",
+  "author_type": "first-party",
+  "contract": "example-v1",
+  "repository": "https://github.com/Groupthink-dev/domain-scope-single-honest-blade-mcp",
+  "install": {
+    "runtime": "uv",
+    "package": "domain-scope-single-honest-blade-mcp"
+  },
+  "risk_class": "read_only",
+  "tools": [
+    {
+      "name": "list_inbox_messages",
+      "description": "List inbox messages for the bound account. Caller cannot select a different account.",
+      "risk_class": "read_only",
+      "granularity": {
+        "scope_filtering": "server-side",
+        "field_projection": "per-field",
+        "deterministic_ordering": "stable",
+        "audit_surface": "structured",
+        "domain_scope": "single"
+      }
+    }
+  ]
+}

--- a/schemas/fixtures/catalog-entries/tool-domain-scope-single-with-scope-arg-violation.json
+++ b/schemas/fixtures/catalog-entries/tool-domain-scope-single-with-scope-arg-violation.json
@@ -1,0 +1,38 @@
+{
+  "name": "domain-scope-single-violation-blade-mcp",
+  "type": "plugin",
+  "description": "DD-333 F.4 fixture — tool declares domain_scope=\"single\" but advertises a `scope` argument with string type. AJV pass; build-catalog emits S-DOM-002 warning (author likely meant \"multi\" since scope arg admits multiple domains).",
+  "version": "1.0.0",
+  "author": "stallari",
+  "license": "MIT",
+  "tier": "community",
+  "author_type": "community",
+  "contract": "example-v1",
+  "repository": "https://github.com/Groupthink-dev/domain-scope-single-violation-blade-mcp",
+  "install": {
+    "runtime": "uv",
+    "package": "domain-scope-single-violation-blade-mcp"
+  },
+  "risk_class": "read_only",
+  "tools": [
+    {
+      "name": "list_records",
+      "description": "List records. Caller passes scope to filter; legacy contradictory declaration.",
+      "risk_class": "read_only",
+      "arguments": [
+        {
+          "name": "scope",
+          "type": "string",
+          "description": "Domain scope filter."
+        }
+      ],
+      "granularity": {
+        "scope_filtering": "server-side",
+        "field_projection": "per-field",
+        "deterministic_ordering": "stable",
+        "audit_surface": "structured",
+        "domain_scope": "single"
+      }
+    }
+  ]
+}

--- a/schemas/fixtures/catalog-entries/tool-domain-scope-unspecified-derives.json
+++ b/schemas/fixtures/catalog-entries/tool-domain-scope-unspecified-derives.json
@@ -1,0 +1,37 @@
+{
+  "name": "domain-scope-unspecified-derives-blade-mcp",
+  "type": "plugin",
+  "description": "DD-333 F.4 fixture — tool lacks granularity.domain_scope but is listed in non_conformance_rationale.domain_scope_unspecified; build-catalog.js derives granularity.domain_scope=\"non-conforming-explicit\" in place.",
+  "version": "1.0.0",
+  "author": "stallari",
+  "license": "MIT",
+  "tier": "community",
+  "author_type": "community",
+  "contract": "example-v1",
+  "repository": "https://github.com/Groupthink-dev/domain-scope-unspecified-derives-blade-mcp",
+  "install": {
+    "runtime": "uv",
+    "package": "domain-scope-unspecified-derives-blade-mcp"
+  },
+  "risk_class": "read_only",
+  "tools": [
+    {
+      "name": "dump_legacy",
+      "description": "Legacy endpoint predating the DD-341 domain substrate.",
+      "risk_class": "read_only",
+      "granularity": {
+        "scope_filtering": "non-conforming-explicit",
+        "field_projection": "none",
+        "deterministic_ordering": "unstable",
+        "audit_surface": "minimal"
+      }
+    }
+  ],
+  "non_conformance_rationale": {
+    "reason": "Upstream provider doesn't expose per-domain partitioning; pre-DD-341 substrate.",
+    "scope_filtering_off": true,
+    "contamination_risks": ["audit-context-leak"],
+    "affected_tools": ["dump_legacy"],
+    "domain_scope_unspecified": ["dump_legacy"]
+  }
+}

--- a/scripts/build-catalog.js
+++ b/scripts/build-catalog.js
@@ -128,6 +128,114 @@ function enforceNonConformanceRationale(raw, filename) {
   }
 }
 
+/**
+ * DD-333 F.4 — heuristic regex matching a user-domain-shaped argument name.
+ * Per spec architect-lock #5: simple narrow heuristic. Tool authors can
+ * disable per-tool via `// scope-arg-disclaimer: <reason>` in description.
+ */
+const DOMAIN_SCOPE_ARG_PATTERN = /^(scope|domain|domains|domainName|domain_name)$/i;
+const DOMAIN_SCOPE_DISCLAIMER_PATTERN = /\/\/\s*scope-arg-disclaimer:/i;
+
+/**
+ * Inspect a tool entry's `arguments[]` (if declared) for a user-domain-shaped
+ * argument that matches DOMAIN_SCOPE_ARG_PATTERN AND has a string-or-enum
+ * type. Returns the matched argument name, or null if none. Strict on type
+ * shape — the heuristic is intentionally narrow per architect-lock #5.
+ */
+function findDomainScopeArg(tool) {
+  const args = Array.isArray(tool && tool.arguments) ? tool.arguments : [];
+  for (const arg of args) {
+    if (!arg || typeof arg.name !== "string") continue;
+    if (!DOMAIN_SCOPE_ARG_PATTERN.test(arg.name)) continue;
+    // Accept type: "string", type: ["string", ...], or presence of `enum`.
+    const type = arg.type;
+    const hasStringType =
+      type === "string" ||
+      (Array.isArray(type) && type.includes("string")) ||
+      Array.isArray(arg.enum);
+    if (hasStringType) return arg.name;
+  }
+  return null;
+}
+
+/**
+ * DD-333 F.4 — procedural cross-field gate for granularity.domain_scope.
+ *
+ * Two responsibilities:
+ *   1. Derivation: for each tool listed in
+ *      `non_conformance_rationale.domain_scope_unspecified` whose own
+ *      `granularity.domain_scope` is omitted, mutate in place with
+ *      "non-conforming-explicit". Sister to scope_filtering derivation in
+ *      enforceNonConformanceRationale.
+ *   2. Constraint A: every name in `domain_scope_unspecified` MUST appear
+ *      as a `tools[].name`. Throws on mismatch (mirrors affected_tools gate).
+ *   3. S-DOM-002 finding: for each tool whose effective `granularity.domain_scope`
+ *      is "single" AND tools[].arguments[] declares a user-domain-shaped arg
+ *      matching DOMAIN_SCOPE_ARG_PATTERN, emit a warning-level finding to
+ *      the build output. If the tool's `description` contains a
+ *      `// scope-arg-disclaimer: <reason>` annotation, emit an info-level
+ *      finding instead (per architect-lock #5 advisory).
+ *
+ * @param {object} raw - plugin catalog entry (mutated for derivation step)
+ * @param {string} filename - source file name for finding context
+ * @returns {Array<{level: "warning"|"info", id: "S-DOM-002", message: string}>}
+ *   list of findings (empty = clean)
+ * @throws {Error} on Constraint A failure
+ */
+function enforceDomainScope(raw, filename) {
+  const findings = [];
+  const rationale = raw.non_conformance_rationale;
+  const tools = Array.isArray(raw.tools) ? raw.tools : [];
+  const toolNames = new Set(
+    tools.map((t) => t && t.name).filter((n) => typeof n === "string"),
+  );
+  const unspecified = new Set(
+    rationale && Array.isArray(rationale.domain_scope_unspecified)
+      ? rationale.domain_scope_unspecified
+      : [],
+  );
+
+  // Constraint A — domain_scope_unspecified cross-reference.
+  if (unspecified.size > 0) {
+    const missing = [...unspecified].filter((name) => !toolNames.has(name));
+    if (missing.length > 0) {
+      throw new Error(
+        `Catalog entry ${raw.name || filename}: non_conformance_rationale.domain_scope_unspecified references tool names not present in tools[]: ${missing.map((n) => `"${n}"`).join(", ")}. Every entry in domain_scope_unspecified MUST cross-reference an actual tools[].name. See stallari-pack-spec/docs/domain-scope.md.`,
+      );
+    }
+  }
+
+  // Derivation — mutate granularity.domain_scope in place for each unspecified
+  // tool that lacks its own declaration. Idempotent (skip when already set).
+  for (const tool of tools) {
+    if (!tool || typeof tool.name !== "string") continue;
+    if (!unspecified.has(tool.name)) continue;
+    if (!tool.granularity || typeof tool.granularity !== "object") continue;
+    if (tool.granularity.domain_scope) continue;
+    tool.granularity.domain_scope = "non-conforming-explicit";
+  }
+
+  // S-DOM-002 — scan each tool for a user-domain-shaped scope arg that
+  // contradicts a `single` declaration.
+  for (const tool of tools) {
+    if (!tool || typeof tool.name !== "string") continue;
+    const declared = tool.granularity && tool.granularity.domain_scope;
+    if (declared !== "single") continue;
+    const scopeArgName = findDomainScopeArg(tool);
+    if (!scopeArgName) continue;
+    const description = typeof tool.description === "string" ? tool.description : "";
+    const hasDisclaimer = DOMAIN_SCOPE_DISCLAIMER_PATTERN.test(description);
+    const message = `S-DOM-002 ${raw.name || filename}/${tool.name}: granularity.domain_scope=\"single\" but tool advertises user-domain-shaped argument \"${scopeArgName}\" (matches /^(scope|domain|domains|domainName|domain_name)$/i with string-or-enum type). Author likely meant domain_scope=\"multi\" since the scope argument admits multiple domains. If this is intentional (e.g. scope arg accepts only one value at a time), add a `// scope-arg-disclaimer: <reason>` annotation to the tool description to downgrade this finding to info-level.`;
+    findings.push({
+      level: hasDisclaimer ? "info" : "warning",
+      id: "S-DOM-002",
+      message,
+    });
+  }
+
+  return findings;
+}
+
 /** Convert a pack name to a URL-safe kebab-case slug: "Business Operations" → "business-operations" */
 function slugify(name) {
   return name
@@ -672,6 +780,7 @@ async function main() {
 
   const entries = [];
   const uxWarnings = []; // [{ name, warnings: [] }]
+  const domainScopeFindings = []; // [{ name, findings: [{level, id, message}] }] — DD-333 F.4
 
   // Plugins
   for (const file of pluginFiles) {
@@ -700,6 +809,18 @@ async function main() {
     // uniform regardless of whether granularity was author-declared or
     // rationale-derived.
     enforceNonConformanceRationale(raw, file);
+
+    // DD-333 F.4 — procedural cross-field gate for granularity.domain_scope.
+    // Derives "non-conforming-explicit" for tools listed in
+    // non_conformance_rationale.domain_scope_unspecified AND emits S-DOM-002
+    // findings when a tool declares domain_scope="single" but advertises a
+    // user-domain-shaped scope argument (likely meant "multi"). Findings are
+    // surfaced post-build alongside Manifest UX warnings; they do not fail
+    // the build at F.4 (severity warning, mirrors S-DOM-001 v1 posture).
+    const dsFindings = enforceDomainScope(raw, file);
+    if (dsFindings.length > 0) {
+      domainScopeFindings.push({ name: raw.name || file, findings: dsFindings });
+    }
 
     const warnings = validatePluginUX(raw);
     if (warnings.length > 0) {
@@ -842,6 +963,31 @@ async function main() {
     console.log(`Output: dist/packs/ (${packCount} pack manifests)`);
   }
 
+  // DD-333 F.4 — S-DOM-002 findings report. Severity is .warning at F.4
+  // (mirrors S-DOM-001 v1 posture); promotion to .error follows A.2.dom
+  // blade backfill (separate spec).
+  if (domainScopeFindings.length > 0) {
+    console.log("");
+    const warnCount = domainScopeFindings.reduce(
+      (sum, e) => sum + e.findings.filter((f) => f.level === "warning").length,
+      0,
+    );
+    const infoCount = domainScopeFindings.reduce(
+      (sum, e) => sum + e.findings.filter((f) => f.level === "info").length,
+      0,
+    );
+    console.log(
+      `DD-333 F.4 S-DOM-002 — ${warnCount} warning(s) + ${infoCount} info finding(s) across ${domainScopeFindings.length} plugin(s):`,
+    );
+    for (const { name, findings } of domainScopeFindings) {
+      console.log(`  ${name}:`);
+      for (const f of findings) {
+        const tag = f.level === "info" ? "[info]" : "[warn]";
+        console.log(`    ${tag} ${f.message}`);
+      }
+    }
+  }
+
   // Manifest UX quality report — install-dialog completeness across plugins
   if (uxWarnings.length > 0) {
     const strict = process.env.STRICT_UX === "1";
@@ -872,6 +1018,10 @@ export {
   validatePluginUX,
   validateCatalogEntry,
   loadCatalogEntryValidator,
+  enforceDomainScope,
+  findDomainScopeArg,
+  DOMAIN_SCOPE_ARG_PATTERN,
+  DOMAIN_SCOPE_DISCLAIMER_PATTERN,
 };
 
 // Run main() only when executed directly (not imported as a module)

--- a/scripts/domain-scope.test.js
+++ b/scripts/domain-scope.test.js
@@ -1,0 +1,187 @@
+/**
+ * DD-333 F.4 — granularity.domain_scope schema + S-DOM-002 procedural gate tests.
+ *
+ * Six test cases per spec § "Test cases stallari-plugins":
+ *   1. acceptsHonestSingleDeclaration         — AJV pass, no finding.
+ *   2. acceptsHonestMultiDeclaration          — AJV pass.
+ *   3. rejectsUnknownEnumValue                — AJV reject.
+ *   4. derivesNonConformingForUnspecified     — build-catalog derives "non-conforming-explicit".
+ *   5. warnsOnSingleWithScopeArg              — procedural emits warning finding.
+ *   6. passesWithDisclaimerAnnotation         — same as #5 but description carries
+ *                                               `// scope-arg-disclaimer:`; finding downgrades to info.
+ *
+ * Existing 11 packs + 59 plugin entries in plugins/tools/ have no domain_scope
+ * declared today; build-catalog.js must remain clean (zero new findings). The
+ * "real-corpus smoke" suite below asserts this.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import {
+  validateCatalogEntry,
+  enforceDomainScope,
+  findDomainScopeArg,
+  DOMAIN_SCOPE_ARG_PATTERN,
+} from "./build-catalog.js";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const FIXTURE_DIR = join(ROOT, "schemas", "fixtures", "catalog-entries");
+const BUILD_SCRIPT = join(ROOT, "scripts", "build-catalog.js");
+
+function loadFixture(name) {
+  return JSON.parse(readFileSync(join(FIXTURE_DIR, name), "utf-8"));
+}
+
+describe("DD-333 F.4 — granularity.domain_scope AJV gate", () => {
+  it("acceptsHonestSingleDeclaration — single tool bound to one domain, no scope arg", async () => {
+    const entry = loadFixture("tool-domain-scope-single-honest.json");
+    const verdict = await validateCatalogEntry(entry);
+    assert.equal(verdict.valid, true, verdict.errorsText);
+    const findings = enforceDomainScope(entry, "single-honest");
+    assert.equal(findings.length, 0, `Expected no findings; got: ${JSON.stringify(findings)}`);
+  });
+
+  it("acceptsHonestMultiDeclaration — multi-domain tool with scope arg", async () => {
+    const entry = loadFixture("tool-domain-scope-multi-honest.json");
+    const verdict = await validateCatalogEntry(entry);
+    assert.equal(verdict.valid, true, verdict.errorsText);
+    // multi + scope arg is the contractually-consistent shape — no finding emitted.
+    const findings = enforceDomainScope(entry, "multi-honest");
+    assert.equal(findings.length, 0, `Expected no findings; got: ${JSON.stringify(findings)}`);
+  });
+
+  it("rejectsUnknownEnumValue — domain_scope: \"magic\" fails AJV", async () => {
+    const entry = loadFixture("tool-domain-scope-bogus-enum.json");
+    const verdict = await validateCatalogEntry(entry);
+    assert.equal(verdict.valid, false);
+    const hasEnumError = verdict.errors.some(
+      (e) =>
+        e.keyword === "enum" &&
+        e.instancePath.includes("/tools/0/granularity/domain_scope"),
+    );
+    assert.ok(
+      hasEnumError,
+      `Expected enum error on /tools/0/granularity/domain_scope; got: ${verdict.errorsText}`,
+    );
+  });
+});
+
+describe("DD-333 F.4 — procedural cross-field gate (enforceDomainScope)", () => {
+  it("derivesNonConformingForUnspecified — tool in domain_scope_unspecified gets non-conforming-explicit", async () => {
+    const entry = loadFixture("tool-domain-scope-unspecified-derives.json");
+    // AJV passes (the fixture's existing granularity block omits domain_scope only).
+    const verdict = await validateCatalogEntry(entry);
+    assert.equal(verdict.valid, true, verdict.errorsText);
+    // Pre-derivation: tool has no domain_scope.
+    assert.equal(entry.tools[0].granularity.domain_scope, undefined);
+    // Post-derivation: mutated in place.
+    const findings = enforceDomainScope(entry, "unspecified-derives");
+    assert.equal(
+      entry.tools[0].granularity.domain_scope,
+      "non-conforming-explicit",
+      "expected derivation to mutate granularity.domain_scope",
+    );
+    // No S-DOM-002 finding (domain_scope is not "single" post-derivation).
+    assert.equal(findings.length, 0);
+  });
+
+  it("warnsOnSingleWithScopeArg — domain_scope=single + scope arg emits warning", () => {
+    const entry = loadFixture("tool-domain-scope-single-with-scope-arg-violation.json");
+    const findings = enforceDomainScope(entry, "single-violation");
+    assert.equal(findings.length, 1, `Expected exactly 1 finding; got: ${JSON.stringify(findings)}`);
+    const f = findings[0];
+    assert.equal(f.id, "S-DOM-002");
+    assert.equal(f.level, "warning");
+    assert.match(f.message, /domain_scope="single"/);
+    assert.match(f.message, /"scope"/);
+  });
+
+  it("passesWithDisclaimerAnnotation — same shape with disclaimer downgrades to info", () => {
+    const entry = loadFixture("tool-domain-scope-disclaimer.json");
+    const findings = enforceDomainScope(entry, "disclaimer");
+    assert.equal(findings.length, 1, `Expected exactly 1 finding; got: ${JSON.stringify(findings)}`);
+    const f = findings[0];
+    assert.equal(f.id, "S-DOM-002");
+    assert.equal(f.level, "info", "disclaimer annotation should downgrade warning → info");
+  });
+
+  it("throws on domain_scope_unspecified cross-reference mismatch (Constraint A)", () => {
+    const entry = {
+      name: "ds-mismatch-blade",
+      version: "1.0.0",
+      author: "stallari",
+      type: "plugin",
+      tools: [{ name: "list_records" }],
+      non_conformance_rationale: {
+        reason: "test",
+        scope_filtering_off: true,
+        contamination_risks: ["audit-context-leak"],
+        affected_tools: ["list_records"],
+        domain_scope_unspecified: ["nonexistent_tool"],
+      },
+    };
+    assert.throws(
+      () => enforceDomainScope(entry, "mismatch"),
+      /domain_scope_unspecified references tool names not present in tools\[\]/,
+    );
+  });
+
+  it("findDomainScopeArg recognises the canonical names", () => {
+    const names = ["scope", "Scope", "domain", "domains", "domainName", "domain_name"];
+    for (const n of names) {
+      assert.ok(DOMAIN_SCOPE_ARG_PATTERN.test(n), `expected match: ${n}`);
+      const arg = findDomainScopeArg({ arguments: [{ name: n, type: "string" }] });
+      assert.equal(arg, n);
+    }
+  });
+
+  it("findDomainScopeArg ignores non-domain-shaped names", () => {
+    const arg = findDomainScopeArg({
+      arguments: [
+        { name: "query", type: "string" },
+        { name: "limit", type: "integer" },
+      ],
+    });
+    assert.equal(arg, null);
+  });
+
+  it("findDomainScopeArg requires string-ish type", () => {
+    // Integer-typed `scope` is not a domain selector.
+    const arg = findDomainScopeArg({ arguments: [{ name: "scope", type: "integer" }] });
+    assert.equal(arg, null);
+    // Enum without type still counts (treated as string-shaped).
+    const arg2 = findDomainScopeArg({
+      arguments: [{ name: "scope", enum: ["a", "b"] }],
+    });
+    assert.equal(arg2, "scope");
+  });
+});
+
+describe("DD-333 F.4 — real plugins/tools/ corpus remains clean", () => {
+  // Smoke: invoking the real build script over the real plugins/tools/
+  // directory MUST emit zero S-DOM-002 warnings (no plugin entry today
+  // declares domain_scope). Any drift surfaces here.
+  it("zero S-DOM-002 warnings on real corpus", () => {
+    const result = spawnSync(process.execPath, [BUILD_SCRIPT], {
+      cwd: ROOT,
+      encoding: "utf-8",
+      env: { ...process.env, NODE_NO_WARNINGS: "1" },
+    });
+    if (result.status !== 0) {
+      assert.fail(
+        `build-catalog.js failed on real corpus:\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+      );
+    }
+    // The build emits "DD-333 F.4 S-DOM-002 —" header only when findings
+    // exist. Its absence means clean.
+    assert.doesNotMatch(
+      result.stdout,
+      /S-DOM-002 — \d+ warning/,
+      `Expected zero S-DOM-002 warnings; got stdout:\n${result.stdout}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Ships the **stallari-plugins** portion of DD-333 Phase F.4 — the 5th `granularity:` dimension (`domain_scope: single | multi | non-conforming-explicit`) plus the build-catalog procedural cross-field gate that surfaces `S-DOM-002` findings when a tool's `domain_scope=\"single\"` declaration is contradicted by a user-domain-shaped `scope`/`domain`/`domainName` argument.

Cross-DD with DD-341 (domain substrate, all phases shipped 2026-05-22 in `v0.99.26.0`) and DD-338 (forthcoming A.2.dom blade `_meta.domain_attribution` substrate). Sister to F.1's `non_conformance_rationale` mechanism.

## Changes

**Schema** — `schemas/catalog-entry.schema.json`:
- `granularity.domain_scope` enum `[single, multi, non-conforming-explicit]`. Optional at F.4 (architect-lock #2 — promoted to required at F.4.b after A.2.dom blade backfill).
- `non_conformance_rationale.domain_scope_unspecified: array<string>` — additive escape hatch listing tools that cannot yet declare `domain_scope`.

**`scripts/build-catalog.js`** — new `enforceDomainScope(raw, filename)` procedural pass invoked per plugin entry inside the build loop:
1. **Derivation** — tools in `domain_scope_unspecified` without own declaration receive `granularity.domain_scope=\"non-conforming-explicit\"` in place (sister to existing `scope_filtering` derivation).
2. **Constraint A** — every entry in `domain_scope_unspecified` must cross-reference an actual `tools[].name`; throws on mismatch.
3. **S-DOM-002 finding** — for each tool with effective `domain_scope=\"single\"` advertising a user-domain-shaped argument matching `/^(scope|domain|domains|domainName|domain_name)$/i` with string-or-enum type, emit a `warning`-level finding. If `tool.description` contains a `// scope-arg-disclaimer: <reason>` annotation (architect-lock #5), downgrade to `info`.

Findings surface alongside Manifest UX warnings; severity `.warning` at F.4 ship (mirrors S-DOM-001 v1 posture per architect-lock #7; promotion to `.error` follows A.2.dom backfill via separate spec).

**Fixtures** — `schemas/fixtures/catalog-entries/tool-domain-scope-*.json` (6 new):
- `single-honest`, `multi-honest`, `single-with-scope-arg-violation`, `unspecified-derives`, `disclaimer`, `bogus-enum`.

**Example packs** — `examples/domain-scope-pack/` (3 new YAMLs):
- Authoring-reference packs for the three authoring paths (honest-single, honest-multi, violation-with-fix-paths).

**Tests** — `scripts/domain-scope.test.js` (8 cases):
- Covers all 6 spec acceptance criteria (acceptsHonestSingle / acceptsHonestMulti / rejectsUnknownEnumValue / derivesNonConformingForUnspecified / warnsOnSingleWithScopeArg / passesWithDisclaimerAnnotation) plus cross-reference mismatch + heuristic regex coverage + real-corpus smoke (zero findings on existing 11 packs + 59 plugin entries).

## Verification

- `npm test` — **178/178 green** (incl. 8 new domain-scope cases; pre-existing 170 unaffected).
- `node scripts/build-catalog.js` — clean against existing 11 packs + 59 plugin entries (zero new S-DOM-002 findings, zero new AJV rejections; no `domain_scope:` declared anywhere in the corpus yet).

## Out of scope (per spec)

- stallari-secops-scanner S-DOM-002 rule (separate subagent / separate PR).
- stallari-pack-spec docs/CHANGELOG (separate subagent / separate PR).
- Blade-side `_meta.domain_attribution` substrate (DD-338 A.2.dom).
- Promoting `domain_scope` to required in `granularity.required` (F.4.b).
- Promoting S-DOM-002 severity to `.error` (post-A.2.dom).
- F.5 (assembler verdict logic consuming `domain_scope`).

## Test plan

- [ ] Architect-attended CI green on PR
- [ ] Reviewer confirms zero S-DOM-002 findings on the existing live corpus (build-catalog.js output)
- [ ] Reviewer scans the 6 fixture files for shape clarity (each documents one branch of the new procedural pass)
- [ ] Reviewer confirms 3 example pack YAMLs serve as readable authoring references (not parsed by build — pure documentation)

## Convention compliance

- **#17 commit trailers** — exactly one `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>`; commit ssh-signed by Piers.
- **#19 no phone-home** — build-catalog runs offline.
- **#22 migration resilience** — `domain_scope` optional; legacy corpus continues to validate.
- **#23 substrate-contract reader audit** — F.4 adds a NEW reader contract (build-catalog.js as reader of `tools[].arguments[]` for scope-arg heuristic). Architect appends DD-333 reader-audit table extension post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)