### PR TITLE
DD-338 Phase B.1.b — google-home deterministic_ordering: unstable → stable on 6 rows

### DIFF
--- a/plugins/tools/google-home-blade-mcp.json
+++ b/plugins/tools/google-home-blade-mcp.json
@@ -80,7 +80,7 @@
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -91,7 +91,7 @@
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -102,7 +102,7 @@
       "granularity": {
         "scope_filtering": "client-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -201,7 +201,7 @@
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -212,7 +212,7 @@
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -223,7 +223,7 @@
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     }


### PR DESCRIPTION
## Summary

Flip `granularity.deterministic_ordering: unstable → stable` on six multi-record google-home tools whose blade-side sort wrapper landed in `google-home-blade-mcp` via the sibling PR.

**6 rows flipped** in `plugins/tools/google-home-blade-mcp.json`:

- `ghome_structures` / `ghome_rooms` / `ghome_devices` (line 83/94/105)
- `ghome_events` / `ghome_status` / `ghome_thermostats` (line 204/215/226)

No other `granularity.*` fields change at B.1.b — `scope_filtering` flips are a future Phase A wave (deferred while refuse-counts stay low); `_meta` audit-surface flips land at Phase C.

## cf_d1_query honest-unstable carve-out (architect-ratified PRIMARY OQ)

Per architect lock #1 on spec `specs/2026-05-23-dd-338-b1b-ghome-cloudflare.md` § Architect amendments, **`cf_d1_query` in `plugins/tools/cloudflare-blade-mcp.json` intentionally stays `deterministic_ordering: unstable` — no catalog change**. User-supplied SQL precludes blade-side re-ordering: sorting would clobber caller-provided `ORDER BY` clauses and hide set-nondeterminism in the user's own query. Mirrors the Tailscale A.1 honest-`client-side` declaration. The DD-333 verdict logic continues to refuse-at-evidentiary on `unstable`, which is contract behaviour, not a defect.

The `_note_unstable` schema-extension probe in the spec § 4.2 is not exercised — keeping cloudflare-blade-mcp.json untouched is the cleaner outcome, with the carve-out documented in the architect-ratified spec.

## Convention #23

Reader-audit advances 37 → 38 migrated blade-tool-sets — catalog declaration is a reader of the tool's ordering contract; the blade-side change + this catalog flip land in the same PR family.

## Test plan

- [x] `node --test scripts/*.test.js` green: 164 pass / 0 fail / 14 skipped
- [x] DD-333 catalog-entry schema gate green for google-home-blade-mcp.json
- [x] All other granularity fields verified untouched

## Companion PR

Blade-side sort wrapper: https://github.com/Groupthink-dev/google-home-blade-mcp/pull/1

Spec: `specs/2026-05-23-dd-338-b1b-ghome-cloudflare.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)