### PR TITLE
DD-338 Phase B.1.b — catalog flip ordering stable on gmail+fastmail (7 tools)

### DIFF
--- a/plugins/tools/fastmail-blade-mcp.json
+++ b/plugins/tools/fastmail-blade-mcp.json
@@ -3,7 +3,7 @@
   "title": "Fastmail",
   "description": "Fastmail email operations via JMAP — search, read, send, manage, masked email, push notifications",
   "tagline": "Full Fastmail control via JMAP with masked email",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": "groupthink-dev",
   "license": "MIT",
   "icon": "/icons/fastmail-blade-mcp.svg",
@@ -75,23 +75,23 @@
     },
     {
       "name": "fastmail_identities",
-      "description": "List sender identities (ID, name, email) — used by mail_send + mail_reply.",
+      "description": "List sender identities (ID, name, email) — used by mail_send + mail_reply. Stable ordering by id asc.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
     {
       "name": "mail_mailboxes",
-      "description": "List all mailboxes — ID, name, total/unread counts, role.",
+      "description": "List all mailboxes — ID, name, total/unread counts, role. Stable ordering by sortOrder asc (then name, id).",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -353,6 +353,6 @@
     "required": "3/3",
     "recommended": "2/2",
     "optional": "3/3",
-    "last_tested": "2026-03-25"
+    "last_tested": "2026-05-23"
   }
 }

--- a/plugins/tools/gmail-blade-mcp.json
+++ b/plugins/tools/gmail-blade-mcp.json
@@ -3,7 +3,7 @@
   "title": "Google Gmail",
   "description": "Gmail email operations via Google API \u2014 search, read, send, threads, labels, drafts, filters. Gemini-powered classification and summarisation.",
   "tagline": "Gmail management with Gemini-powered classification",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "groupthink-dev",
   "license": "MIT",
   "icon": "/icons/gmail-blade-mcp.svg",
@@ -64,12 +64,12 @@
   "tools": [
     {
       "name": "gmail_search",
-      "description": "Search messages by Gmail query language (from:, to:, subject:, has:, newer_than:, etc.). Server-side filter with DD-278 scope-tag wrapper (scope=work|personal|family|public).",
+      "description": "Search messages by Gmail query language (from:, to:, subject:, has:, newer_than:, etc.). Server-side filter with DD-278 scope-tag wrapper (scope=work|personal|family|public). Stable ordering by internalDate desc, id asc.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "structured"
       }
     },
@@ -86,12 +86,12 @@
     },
     {
       "name": "gmail_snippets",
-      "description": "Compact snippet view across recent or filtered messages. DD-278 scope-tag wrapper (scope=work|personal|family|public).",
+      "description": "Compact snippet view across recent or filtered messages. DD-278 scope-tag wrapper (scope=work|personal|family|public). Stable ordering by internalDate desc, id asc.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "structured"
       }
     },
@@ -108,12 +108,12 @@
     },
     {
       "name": "gmail_mailboxes",
-      "description": "List all labels (mailboxes) in the account.",
+      "description": "List all labels (mailboxes) in the account. Stable ordering by name asc (case-folded), id asc.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -152,23 +152,23 @@
     },
     {
       "name": "gmail_identities",
-      "description": "Send-as identities and aliases configured in the account.",
+      "description": "Send-as identities and aliases configured in the account. Stable ordering by sendAsEmail asc (case-folded).",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
     {
       "name": "gmail_filters",
-      "description": "Server-side filter rules configured in the account.",
+      "description": "Server-side filter rules configured in the account. Stable ordering by id asc.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -400,6 +400,6 @@
     "required": "3/3",
     "recommended": "2/2",
     "optional": "3/3",
-    "last_tested": "2026-03-27"
+    "last_tested": "2026-05-23"
   }
 }


### PR DESCRIPTION
## Summary

- Flip `granularity.deterministic_ordering: unstable → stable` on 7 multi-record mail-shaped tools (5 gmail + 2 fastmail) — paired with sort-before-return impl in sibling blade-mcp PRs.
- Tool-description sentences appended per spec § 4.
- `gmail-blade-mcp.json` catalog version 0.3.0 → 0.4.0; `fastmail-blade-mcp.json` 0.1.1 → 0.2.0; `conformance.last_tested` stamped 2026-05-23 on both.

## Sibling PRs

- gmail-blade-mcp impl PR: https://github.com/Groupthink-dev/gmail-blade-mcp/pull/2
- fastmail-blade-mcp impl PR: https://github.com/Groupthink-dev/fastmail-blade-mcp/pull/1

## Convention #23 advance

+2 blade-tool-sets migrated. Feeds DD-333 Phase E refuse-envelope gate. Reverts are independent per DD-338 spec § 13 — consumer tolerance for unstable ordering pre-B.1.b is additive only.

## Tests

- Catalog rebuild + `npm test` green: 164 passed, 14 skipped, 0 failed (no regressions).

## Test plan

- [ ] CI green on `feat/dd-338-b1b-gmail-fastmail` (npm test on catalog rebuild)
- [ ] Architect merges sibling blade-mcp PRs first; this catalog PR is safe to merge in parallel or after
- [ ] DD-333 Phase C live-MCP probe (when it lands) re-verifies the `stable` declaration end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)