### PR TITLE
DD-338 Phase B.1.b — mastodon catalog flips (19 rows: unstable -> stable)

### DIFF
--- a/plugins/tools/mastodon-blade-mcp.json
+++ b/plugins/tools/mastodon-blade-mcp.json
@@ -47,7 +47,7 @@
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "structured"
       }
     },
@@ -58,7 +58,7 @@
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -69,7 +69,7 @@
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -80,7 +80,7 @@
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -91,7 +91,7 @@
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -124,7 +124,7 @@
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "structured"
       }
     },
@@ -146,7 +146,7 @@
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "structured"
       }
     },
@@ -168,7 +168,7 @@
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -179,7 +179,7 @@
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -190,7 +190,7 @@
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "structured"
       }
     },
@@ -201,7 +201,7 @@
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -212,7 +212,7 @@
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -223,7 +223,7 @@
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -234,7 +234,7 @@
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -245,7 +245,7 @@
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -256,7 +256,7 @@
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -267,7 +267,7 @@
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -278,7 +278,7 @@
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -289,7 +289,7 @@
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },


### PR DESCRIPTION
## Summary

Catalog half of DD-338 Phase B.1.b: flip `granularity.deterministic_ordering` from `"unstable"` to `"stable"` on all 19 multi-record read tool rows for `mastodon-blade-mcp`.

Atomic with the handler-side sort-before-return discipline landing in the paired blade-mcp PR — each tool now applies a canonical sort (id desc / id asc / preserve-rank-with-tie-break per the per-tool table in the spec § 2) and the N=5 byte-equal pytest harness on the blade-mcp side is the hard gate that proves the declaration is honest per [DD-333](https://github.com/Groupthink-dev/stallari-plugins/pull/15) Phase A.

## 19 rows flipped

| Tool | Catalog line | Sort key |
|---|---|---|
| `mastodon_timeline_home` | 50 | id desc |
| `mastodon_timeline_public` | 61 | id desc |
| `mastodon_timeline_local` | 72 | id desc |
| `mastodon_timeline_hashtag` | 83 | id desc |
| `mastodon_timeline_list` | 94 | id desc |
| `mastodon_search` | 127 | per-bucket (id desc accounts/statuses; name asc hashtags) |
| `mastodon_account_statuses` | 149 | id desc |
| `mastodon_followers` | 171 | id desc |
| `mastodon_following` | 182 | id desc |
| `mastodon_notifications` | 193 | id desc |
| `mastodon_trending_tags` | 204 | preserve rank + name asc tie-break |
| `mastodon_trending_statuses` | 215 | preserve rank + id desc tie-break |
| `mastodon_trending_links` | 226 | preserve rank + url asc tie-break |
| `mastodon_bookmarks` | 237 | id desc |
| `mastodon_favourites` | 248 | id desc |
| `mastodon_lists` | 259 | id asc |
| `mastodon_list_accounts` | 270 | id desc |
| `mastodon_conversations` | 281 | id desc |
| `mastodon_filters` | 292 | id asc |

No other granularity fields touched (`audit_surface` flips remain Phase C scope per spec § 3.3 / NOT_PERMITTED #6). No tool-row reordering. Single-file edit per the hand-edited-mirror convention — `mastodon-blade-mcp` has no in-tree `pack.yaml`, so the catalog is the only declarations surface for this blade.

## Pair PR

Paired with [Groupthink-dev/mastodon-blade-mcp#3](https://github.com/Groupthink-dev/mastodon-blade-mcp/pull/3) which carries the handler-side sort calls, helper functions in `formatters.py`, and the 41 new pytest cases.

## Test plan

- [x] `node scripts/build-catalog.js` green — 59 plugins + 11 packs = 70 entries, schema validation green (the 19 flips pass AJV)
- [x] `node scripts/build-forge-context.js` green — generates `scripts/generated/declared-services.js` (prerequisite for `npm test`)
- [x] `npm test` green — 164 / 164 pass, 0 failures
- [ ] Architect to merge atomically with the blade-mcp PR (catalog/implementation drift is a class-of-bug per DD-333 Phase A; honour the spec § 12 architect approval that both PRs land together)

🤖 Generated with [Claude Code](https://claude.com/claude-code)