### PR TITLE
DD-338 Phase B.2 — caldav-blade-mcp catalog flips (1 stable + 5 unsorted)

### DIFF
--- a/plugins/tools/caldav-blade-mcp.json
+++ b/plugins/tools/caldav-blade-mcp.json
@@ -69,7 +69,7 @@
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "stable",
         "audit_surface": "minimal"
       }
     },
@@ -80,7 +80,7 @@
       "granularity": {
         "scope_filtering": "none",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "unsorted",
         "audit_surface": "minimal"
       }
     },
@@ -102,7 +102,7 @@
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "unsorted",
         "audit_surface": "minimal"
       }
     },
@@ -124,7 +124,7 @@
       "granularity": {
         "scope_filtering": "client-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "unsorted",
         "audit_surface": "minimal"
       }
     },
@@ -135,7 +135,7 @@
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "unsorted",
         "audit_surface": "minimal"
       }
     },
@@ -146,7 +146,7 @@
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
-        "deterministic_ordering": "unstable",
+        "deterministic_ordering": "unsorted",
         "audit_surface": "minimal"
       }
     },


### PR DESCRIPTION
## Summary

Catalog-side of DD-338 Phase B.2. Paired with [`caldav-blade-mcp` PR #1](https://github.com/Groupthink-dev/caldav-blade-mcp/pull/1) (source-side changes + tests).

Six `granularity.deterministic_ordering` flips on `caldav-blade-mcp.json`:

| Tool | Old | New | Rationale |
|---|---|---|---|
| `cal_info` | `unstable` | `stable` | Single-record return — trivially satisfies the byte-identical contract per B.1.a precedent |
| `cal_calendars` | `unstable` | `unsorted` | Multi-provider — no atomic cross-provider sort guarantee |
| `cal_events_batch` | `unstable` | `unsorted` | Per-calendar grouped; cross-provider set-semantics |
| `cal_search` | `unstable` | `unsorted` | Cross-provider event interleave is honest-set |
| `cal_today` | `unstable` | `unsorted` | Multi-provider grouped |
| `cal_week` | `unstable` | `unsorted` | Multi-provider grouped |

## Honest-degraded-declaration precedent

The `unsorted` declarations mirror the architect-ratified `cf_d1_query` precedent from B.1.b (joined by `tailscale` tag-filter `client-side`). Where the blade cannot honestly fulfil the deterministic contract, **declare what you actually deliver** — set semantics — rather than fake-comply with an internal sort. The assembler downstream is responsible for canonical ordering with full provenance.

DD-338 honest-degraded-declaration registry now has **three** entries:
1. `cf_d1_query` — `unstable` (user-supplied SQL precludes blade-side reorder)
2. `tailscale` tag-filter — `client-side` (server returns full set; blade filters in-process)
3. `cal_*` multi-provider (this PR) — `unsorted` (cross-provider interleave is honest-set)

## Architect OQ locks honoured

- OQ-1 (PRIMARY): honest-unsorted across all 5 multi-record tools ✅
- OQ-2: no defensive sort under `unsorted` declaration ✅
- OQ-3: cal_calendars partial-tolerance softening lands in paired source PR ✅
- OQ-4: error-row render style at implementer's discretion ✅

## Test plan

- [x] `npm test` green: **164/178 passing** (14 skipped, 0 fail) after `node scripts/build-forge-context.js`
- [x] No tool changes its `scope_filtering` or `audit_surface` declaration (out of scope for B.2)

Convention #23 reader-audit advances **43 → 44** migrated blade-tool-sets on merge of both paired PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)