### PR TITLE
DD-338 Phase A.2 (narrowed) — syncthing-blade-mcp catalog flips for list_folders + recent_changes cat-B promotion

### DIFF
--- a/plugins/tools/syncthing-blade-mcp.json
+++ b/plugins/tools/syncthing-blade-mcp.json
@@ -4,7 +4,7 @@
   "title": "Syncthing",
   "description": "Syncthing replication management MCP \u2014 multi-instance, token-efficient output, safe disk-space reclamation. Read and control access to Syncthing's REST API with a focus on replication awareness: knowing which folders are fully replicated across devices so you can confidently reclaim local disk space.",
   "tagline": "Mesh file sync with replication-aware disk reclamation",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "author": "groupthink-dev",
   "license": "MIT",
   "icon": "/icons/syncthing-blade-mcp.svg",
@@ -336,13 +336,13 @@
     },
     {
       "name": "syncthing_list_folders",
-      "description": "List all folders configured on an instance.",
+      "description": "List all folders configured on an instance. (DD-278 `scope=` tag accepted; folder set resolved via `SYNCTHING_<SCOPE>_FOLDERS` env var; _meta envelope tail.)",
       "risk_class": "read_only",
       "granularity": {
-        "scope_filtering": "none",
+        "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -391,13 +391,13 @@
     },
     {
       "name": "syncthing_recent_changes",
-      "description": "Recent file changes across all folders.",
+      "description": "Recent file changes across all folders. (DD-278 `scope=` tag accepted; filters the event stream to events whose `data.folderID` is in the resolved `SYNCTHING_<SCOPE>_FOLDERS` set; _meta envelope tail.)",
       "risk_class": "read_only",
       "granularity": {
-        "scope_filtering": "none",
+        "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {


### PR DESCRIPTION
## Summary

Lockstep catalog change with [Groupthink-dev/syncthing-blade-mcp#5](https://github.com/Groupthink-dev/syncthing-blade-mcp/pull/5)
for the 2 cat-B tools whose runtime gains a `scope=` argument + filter
via the A.1 `_resolve_scope_folders` substrate + `_meta` envelope:

- **`syncthing_list_folders`** — `scope_filtering: none → server-side`;
  `audit_surface: minimal → structured`; description appended with the
  DD-278 `scope=` tag + `SYNCTHING_<SCOPE>_FOLDERS` env-var contract +
  `_meta` envelope tail note.
- **`syncthing_recent_changes`** — same two granularity flips +
  description appended noting the `data.folderID` post-fetch filter shape.

Catalog version: `0.6.1 → 0.7.0` (minor — behaviour-affecting `scope=`
arg added per A.1 + B.1.b minor-bump precedent).

## Scope narrowing per architect amendment 2026-05-23

The original spec covered 34 tools across 3 blade-mcp catalogs (tailscale
+ syncthing + mastodon). Architect narrowed scope to just the 2 cat-B
tools after discovering that `non_conformance_rationale.scope_filtering_unspecified`
is **not** a pack-spec v4.4.0 field — `scope_filtering: none` IS the
conformant declaration for tools without a scope dimension. The 32
cat-A (honest scope_none) + cat-D (write verb) tools in the original
spec are already conformant; no edits to those rows.

## Test plan

- [x] `npm test` green: 164/178 (14 skipped, 0 failed) — covers AJV
  schema validation + pack/catalog conformance + DD-120 sealed gates +
  domain-scope + non-conformance rationale checks.
- [x] `node scripts/build-forge-context.js` runs clean (regenerates the
  declared-services build artefact that `npm test` consumes).

## Convention compliance

- Convention #17: one `Co-Authored-By:` trailer, no `Signed-off-by`.

Closes part of DD-338 Phase A.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)