### PR TITLE
DD-338 Phase C W3-Python catalog flips — fastmail + gmail

### DIFF
--- a/plugins/tools/fastmail-blade-mcp.json
+++ b/plugins/tools/fastmail-blade-mcp.json
@@ -3,7 +3,7 @@
   "title": "Fastmail",
   "description": "Fastmail email operations via JMAP — search, read, send, manage, masked email, push notifications",
   "tagline": "Full Fastmail control via JMAP with masked email",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "groupthink-dev",
   "license": "MIT",
   "icon": "/icons/fastmail-blade-mcp.svg",
@@ -108,35 +108,35 @@
     },
     {
       "name": "mail_search",
-      "description": "Search emails with rich JMAP server-side filters (from, to, subject, body, after/before, in_mailbox, has_keyword, not_keyword, limit).",
+      "description": "Search emails with rich JMAP server-side filters (from, to, subject, body, after/before, in_mailbox, has_keyword, not_keyword, limit). Emits `_meta` envelope disclosing JMAP filter set + match cardinality.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
       "name": "mail_threads",
-      "description": "Get all messages in a thread by ID, ordered chronologically.",
+      "description": "Get all messages in a thread by ID, ordered chronologically. Emits `_meta` envelope disclosing thread scope + message count.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
       "name": "mail_snippets",
-      "description": "Search emails returning short snippets — JMAP server-side filters (from, subject, body, after/before, in_mailbox, limit).",
+      "description": "Search emails returning short snippets — JMAP server-side filters (from, subject, body, after/before, in_mailbox, limit). Emits `_meta` envelope disclosing filter set + match cardinality.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -152,13 +152,13 @@
     },
     {
       "name": "mail_changes",
-      "description": "Get email changes since a previous state — server-side since_state + max_changes.",
+      "description": "Get email changes since a previous state — server-side since_state + max_changes. Emits `_meta` envelope disclosing since-state + change cardinality.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -229,13 +229,13 @@
     },
     {
       "name": "masked_list",
-      "description": "List masked email aliases with server-side state + for_domain + limit filters.",
+      "description": "List masked email aliases with server-side state + for_domain + limit filters. Emits `_meta` envelope disclosing filter set + cardinality.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {

--- a/plugins/tools/gmail-blade-mcp.json
+++ b/plugins/tools/gmail-blade-mcp.json
@@ -3,7 +3,7 @@
   "title": "Google Gmail",
   "description": "Gmail email operations via Google API \u2014 search, read, send, threads, labels, drafts, filters. Gemini-powered classification and summarisation.",
   "tagline": "Gmail management with Gemini-powered classification",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "groupthink-dev",
   "license": "MIT",
   "icon": "/icons/gmail-blade-mcp.svg",
@@ -141,13 +141,13 @@
     },
     {
       "name": "gmail_changes",
-      "description": "Incremental changes since a history ID.",
+      "description": "Incremental changes since a history ID. Emits `_meta` envelope disclosing history watermark + label filter.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {


### PR DESCRIPTION
## Summary

DD-338 Phase C Wave 3 (Cloud+Mail cohort, Python half) catalog flips for `audit_surface: minimal -> structured` on 6 read tools across 2 first-party Python blades. Consumes the blade-side `_meta` envelope ships from fastmail-blade-mcp 0.3.0 and gmail-blade-mcp 0.7.0.

**fastmail** (5 tools, catalog `0.2.0 → 0.3.0`):

- `mail_search`, `mail_threads`, `mail_snippets`, `mail_changes`, `masked_list`

**gmail** (1 tool, catalog `0.4.0 → 0.5.0`):

- `gmail_changes` (the other 4 already-structured tools — `gmail_search`, `gmail_read`, `gmail_snippets`, `gmail_thread` — are untouched)

Each entry's description gains an "Emits `_meta` envelope disclosing ..." suffix per the Wave 3 catalog-flip plan.

## Test plan

- [x] `node scripts/build-catalog.js` succeeds; 59 plugins + 11 packs = 70 entries built
- [x] `npm test` — 164/164 plugin tests pass (after generating `scripts/generated/declared-services.js` via `build-forge-context.js`)
- [x] AJV validation green for both edited catalog entries
- [ ] Sister blade PRs merge first to avoid catalog declaring `structured` against a blade that doesn't yet emit it

## Related

- Spec: `~/master-ai/atlas/utilities/agent-harness/specs/2026-05-23-dd-338-c-w3-cloud-mail.md`
- DD: DD-338 Phase C Wave 3 (Cloud+Mail cohort)
- Companion blade PRs:
  - `Groupthink-dev/fastmail-blade-mcp#2`
  - `Groupthink-dev/gmail-blade-mcp#3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)