### PR TITLE
DD-338 Phase C W2A catalog flips — HA + ghome

### DIFF
--- a/plugins/tools/google-home-blade-mcp.json
+++ b/plugins/tools/google-home-blade-mcp.json
@@ -3,7 +3,7 @@
   "title": "Google Home",
   "description": "Google Home / Nest device control via SDM API \u2014 thermostats, cameras, doorbells, event streams",
   "tagline": "Nest thermostat, camera, and doorbell control via SDM",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": "groupthink-dev",
   "license": "MIT",
   "icon": "/icons/google-home-blade-mcp.svg",
@@ -92,7 +92,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -103,7 +103,7 @@
         "scope_filtering": "client-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -180,7 +180,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "none"
       }
     },
     {
@@ -202,7 +202,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -213,7 +213,7 @@
         "scope_filtering": "none",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -224,7 +224,7 @@
         "scope_filtering": "none",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     }
   ],

--- a/plugins/tools/home-assistant-blade-mcp.json
+++ b/plugins/tools/home-assistant-blade-mcp.json
@@ -3,7 +3,7 @@
   "title": "Home Assistant",
   "description": "Home Assistant operations \u2014 entities, state, history, device control, automations, energy, multi-site management",
   "tagline": "Multi-site Home Assistant control with write gating",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": "groupthink-dev",
   "license": "MIT",
   "icon": "/icons/home-assistant-blade-mcp.svg",
@@ -156,10 +156,10 @@
       "description": "Fuzzy search across entities, devices, areas, and automations. (Track 2 — outer item-type relevance order preserved; each inner per-type list sorted ascending.)",
       "risk_class": "read_only",
       "granularity": {
-        "scope_filtering": "client-side",
+        "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -189,10 +189,10 @@
       "description": "Current state of all entities \u2014 bulk state snapshot. (Track 2 \u2014 canonical sort on entity_id ascending.)",
       "risk_class": "read_only",
       "granularity": {
-        "scope_filtering": "none",
+        "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -214,7 +214,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -225,7 +225,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -258,7 +258,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -423,7 +423,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "none"
       }
     },
     {


### PR DESCRIPTION
## Summary

Catalog-side flips for Subagent A's per-blade PRs:

- HA: https://github.com/Groupthink-dev/home-assistant-blade-mcp/pull/4
- ghome: https://github.com/Groupthink-dev/google-home-blade-mcp/pull/2

Per DD-338 Phase C Wave 2 spec ([[atlas/utilities/agent-harness/specs/2026-05-23-dd-338-c-w2-network-iot]]).

### home-assistant-blade-mcp 0.5.0 → 0.6.0

| Tool | audit_surface | scope_filtering |
|---|---|---|
| ha_search | minimal → **structured** | client-side → **server-side** (OQ-1) |
| ha_history | minimal → **structured** | unchanged |
| ha_logbook | minimal → **structured** | unchanged |
| ha_calendar_events | minimal → **structured** | unchanged |
| ha_states | minimal → **structured** | none → **server-side** (OQ-2) |
| ha_camera_snapshot | minimal → **none** | unchanged (OQ-8 opaque-blob reclassify) |

### google-home-blade-mcp 0.1.1 → 0.2.0

| Tool | audit_surface | scope_filtering |
|---|---|---|
| ghome_rooms | minimal → **structured** | unchanged |
| ghome_devices | minimal → **structured** | unchanged (`client-side` per OQ-3 honest-worst-case) |
| ghome_events | minimal → **structured** | unchanged |
| ghome_status | minimal → **structured** | unchanged |
| ghome_thermostats | minimal → **structured** | unchanged |
| ghome_camera_image | minimal → **none** | unchanged (OQ-2 opaque-blob reclassify) |

## Test plan

- [x] 178/178 npm validate-packs tests green (14 pre-existing skipped)
- [x] JSON parses cleanly
- [x] `node scripts/build-catalog.js` succeeds (59 plugins + 11 packs)

Merge after the two blade PRs land + each blade publishes its new version.