### PR TITLE
DD-338 Phase C W2B catalog flips — syncthing + tailscale + caldav

### DIFF
--- a/plugins/tools/caldav-blade-mcp.json
+++ b/plugins/tools/caldav-blade-mcp.json
@@ -3,7 +3,7 @@
   "title": "Calendar (CalDAV)",
   "description": "CalDAV calendar operations \u2014 protocol-level access to any CalDAV server",
   "tagline": "Universal calendar access over the CalDAV protocol",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": "groupthink-dev",
   "license": "MIT",
   "icon": "/icons/caldav-blade-mcp.svg",
@@ -81,7 +81,7 @@
         "scope_filtering": "none",
         "field_projection": "none",
         "deterministic_ordering": "unsorted",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -92,7 +92,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -103,7 +103,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "unsorted",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -122,10 +122,10 @@
       "description": "Search events by text, attendee email, or location. Optional calendar and date scope.",
       "risk_class": "read_only",
       "granularity": {
-        "scope_filtering": "client-side",
+        "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "unsorted",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -136,7 +136,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "unsorted",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -147,7 +147,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "unsorted",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -158,7 +158,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {

--- a/plugins/tools/syncthing-blade-mcp.json
+++ b/plugins/tools/syncthing-blade-mcp.json
@@ -4,7 +4,7 @@
   "title": "Syncthing",
   "description": "Syncthing replication management MCP \u2014 multi-instance, token-efficient output, safe disk-space reclamation. Read and control access to Syncthing's REST API with a focus on replication awareness: knowing which folders are fully replicated across devices so you can confidently reclaim local disk space.",
   "tagline": "Mesh file sync with replication-aware disk reclamation",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": "groupthink-dev",
   "license": "MIT",
   "icon": "/icons/syncthing-blade-mcp.svg",
@@ -254,7 +254,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -265,7 +265,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -287,7 +287,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -298,7 +298,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {

--- a/plugins/tools/tailscale-blade-mcp.json
+++ b/plugins/tools/tailscale-blade-mcp.json
@@ -3,7 +3,7 @@
   "title": "Tailscale",
   "description": "Tailscale network monitoring and security — device inventory, ACL policy review, DNS configuration, auth key auditing, users, and audit logs",
   "tagline": "Monitor and secure your tailnet — devices, ACLs, keys, DNS, and audit trail",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "groupthink-dev",
   "license": "MIT",
   "icon": "/icons/tailscale-blade-mcp.svg",
@@ -104,7 +104,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {


### PR DESCRIPTION
## Summary

Catalog companion to the 3 sibling blade-mcp PRs (Subagent B half of DD-338 Phase C Wave 2 network+IoT cohort). Flips `audit_surface: minimal → structured` for 12 tools, plus 1 honest `scope_filtering` correction.

**syncthing-blade-mcp** (0.7.0 → 0.8.0) — 4 tools:
- syncthing_folder_errors
- syncthing_browse_folder
- syncthing_folder_need
- syncthing_remote_need

**tailscale-blade-mcp** (0.4.0 → 0.5.0) — 1 tool:
- ts_device_routes

**caldav-blade-mcp** (0.1.1 → 0.2.0) — 7 tools + 1 scope flip:
- cal_calendars (audit_surface)
- cal_events (audit_surface)
- cal_events_batch (audit_surface)
- cal_search (audit_surface + scope_filtering: client-side → server-side per OQ-1; underlying CalDAV REPORT honours all named args server-side)
- cal_today (audit_surface)
- cal_week (audit_surface)
- cal_freebusy (audit_surface)

`cal_event` (single-record by UID) stays `audit_surface: minimal` — non-trivial envelope value would be redundant on a point-fetch.

## Test plan

- [x] `python3 -c "import json; json.load(...)"` per file — JSON validity
- [x] `node scripts/build-catalog.js` — Built catalog: 59 plugins + 11 packs = 70 entries, 37 services
- [x] `node scripts/build-forge-context.js` — generated `scripts/generated/declared-services.js`
- [x] `npm test` — 122/122 pass (after build-forge-context generates the missing dep)

Sibling per-blade PRs:
- Groupthink-dev/syncthing-blade-mcp#6
- Groupthink-dev/tailscale-blade-mcp#4
- Groupthink-dev/caldav-blade-mcp#2

Spec: `2026-05-23-dd-338-c-w2-network-iot.md` (vault)
DD: DD-338 Phase C Wave 2 Subagent B