### PR TITLE
DD-338 Phase C W3-TS catalog flips — CF + Vultr

### DIFF
--- a/plugins/tools/cloudflare-blade-mcp.json
+++ b/plugins/tools/cloudflare-blade-mcp.json
@@ -1,9 +1,9 @@
 {
   "name": "cloudflare-blade-mcp",
   "title": "Cloudflare Edge Platform",
-  "description": "Manage your Cloudflare stack — DNS, Workers, Pages, R2, KV, D1, Tunnels, Vectorize, AI Search, AI Gateway, Workers AI, and cache purge. 78 tools with token-efficient output and safety gates on all writes.",
+  "description": "Manage your Cloudflare stack \u2014 DNS, Workers, Pages, R2, KV, D1, Tunnels, Vectorize, AI Search, AI Gateway, Workers AI, and cache purge. 78 tools with token-efficient output and safety gates on all writes.",
   "tagline": "Full-stack Cloudflare management from DNS to deploy",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "groupthink-dev",
   "license": "MIT",
   "icon": "/icons/cloudflare-blade-mcp.svg",
@@ -64,18 +64,18 @@
     },
     {
       "name": "cf_dns_export_records",
-      "description": "Export a zone's DNS records in BIND format.",
+      "description": "Export a zone's DNS records in BIND format. Emits `_meta` envelope disclosing zone scope and record count.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
       "name": "cf_dns_create_record",
-      "description": "Create a new DNS record in a zone. Write — gated by confirm.",
+      "description": "Create a new DNS record in a zone. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -86,7 +86,7 @@
     },
     {
       "name": "cf_dns_update_record",
-      "description": "Update an existing DNS record. Write — gated by confirm.",
+      "description": "Update an existing DNS record. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -97,7 +97,7 @@
     },
     {
       "name": "cf_dns_delete_record",
-      "description": "Delete a DNS record. Destructive — gated by confirm.",
+      "description": "Delete a DNS record. Destructive \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -108,7 +108,7 @@
     },
     {
       "name": "cf_dns_bulk_create",
-      "description": "Bulk-create DNS records in a zone. Write — gated by confirm.",
+      "description": "Bulk-create DNS records in a zone. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -119,7 +119,7 @@
     },
     {
       "name": "cf_dns_bulk_update",
-      "description": "Bulk-update DNS records in a zone. Write — gated by confirm.",
+      "description": "Bulk-update DNS records in a zone. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -163,7 +163,7 @@
     },
     {
       "name": "cf_kv_put",
-      "description": "Put a KV key-value pair. Write — gated by confirm.",
+      "description": "Put a KV key-value pair. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -174,7 +174,7 @@
     },
     {
       "name": "cf_kv_delete",
-      "description": "Delete a KV key. Destructive — gated by confirm.",
+      "description": "Delete a KV key. Destructive \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -185,7 +185,7 @@
     },
     {
       "name": "cf_kv_bulk_put",
-      "description": "Bulk-put KV key-value pairs. Write — gated by confirm.",
+      "description": "Bulk-put KV key-value pairs. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -196,7 +196,7 @@
     },
     {
       "name": "cf_kv_bulk_delete",
-      "description": "Bulk-delete KV keys. Destructive — gated by confirm.",
+      "description": "Bulk-delete KV keys. Destructive \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -229,18 +229,18 @@
     },
     {
       "name": "cf_d1_query",
-      "description": "Run a read-only SELECT-style SQL query against a D1 database.",
+      "description": "Run a read-only SELECT-style SQL query against a D1 database. Emits `_meta` envelope; ordering remains `unstable` for user-driven SQL (DD-338 B.1.b PRIMARY architect lock).",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "unstable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
       "name": "cf_d1_execute",
-      "description": "Execute a mutating SQL statement (INSERT/UPDATE/DELETE/CREATE/DROP) against a D1 database. Destructive — gated by confirm.",
+      "description": "Execute a mutating SQL statement (INSERT/UPDATE/DELETE/CREATE/DROP) against a D1 database. Destructive \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -251,35 +251,35 @@
     },
     {
       "name": "cf_d1_export",
-      "description": "Export a D1 database as SQL.",
+      "description": "Export a D1 database as SQL. Emits `_meta` envelope disclosing database scope and table count.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
       "name": "cf_d1_list_tables",
-      "description": "List tables in a D1 database.",
+      "description": "List tables in a D1 database. Emits `_meta` envelope disclosing database scope.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
       "name": "cf_d1_describe_table",
-      "description": "Describe schema for a single D1 table.",
+      "description": "Describe schema for a single D1 table. Emits `_meta` envelope disclosing database + table scope.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -306,7 +306,7 @@
     },
     {
       "name": "cf_tunnel_create",
-      "description": "Create a new Cloudflare Tunnel. Write — gated by confirm.",
+      "description": "Create a new Cloudflare Tunnel. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -317,7 +317,7 @@
     },
     {
       "name": "cf_tunnel_delete",
-      "description": "Delete a Cloudflare Tunnel. Destructive — gated by confirm.",
+      "description": "Delete a Cloudflare Tunnel. Destructive \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -328,18 +328,18 @@
     },
     {
       "name": "cf_tunnel_list_configs",
-      "description": "List ingress configurations for a Cloudflare Tunnel.",
+      "description": "List ingress configurations for a Cloudflare Tunnel. Emits `_meta` envelope disclosing tunnel scope.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
       "name": "cf_tunnel_update_config",
-      "description": "Update ingress configuration for a Cloudflare Tunnel. Write — gated by confirm.",
+      "description": "Update ingress configuration for a Cloudflare Tunnel. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -350,13 +350,13 @@
     },
     {
       "name": "cf_tunnel_list_connections",
-      "description": "List active connections for a Cloudflare Tunnel.",
+      "description": "List active connections for a Cloudflare Tunnel. Emits `_meta` envelope disclosing tunnel scope.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -394,7 +394,7 @@
     },
     {
       "name": "cf_workers_create_deployment",
-      "description": "Create a new deployment for a Worker script. Write — gated by confirm.",
+      "description": "Create a new deployment for a Worker script. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -416,18 +416,18 @@
     },
     {
       "name": "cf_workers_list_secrets",
-      "description": "List secret names bound to a Worker script (values not returned).",
+      "description": "List secret names bound to a Worker script (values not returned). Emits `_meta` envelope disclosing script scope.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
       "name": "cf_workers_put_secret",
-      "description": "Put a secret on a Worker script. Write — gated by confirm.",
+      "description": "Put a secret on a Worker script. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -438,7 +438,7 @@
     },
     {
       "name": "cf_workers_delete_secret",
-      "description": "Delete a secret from a Worker script. Destructive — gated by confirm.",
+      "description": "Delete a secret from a Worker script. Destructive \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -460,7 +460,7 @@
     },
     {
       "name": "cf_workers_put_schedules",
-      "description": "Replace cron schedules for a Worker script. Write — gated by confirm.",
+      "description": "Replace cron schedules for a Worker script. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -515,7 +515,7 @@
     },
     {
       "name": "cf_pages_rollback",
-      "description": "Roll back a Pages project to a previous deployment. Destructive — gated by confirm.",
+      "description": "Roll back a Pages project to a previous deployment. Destructive \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -526,18 +526,18 @@
     },
     {
       "name": "cf_pages_list_domains",
-      "description": "List custom domains attached to a Pages project.",
+      "description": "List custom domains attached to a Pages project. Emits `_meta` envelope disclosing project scope.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
       "name": "cf_pages_purge_build_cache",
-      "description": "Purge the build cache for a Pages project. Destructive — gated by confirm.",
+      "description": "Purge the build cache for a Pages project. Destructive \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -570,7 +570,7 @@
     },
     {
       "name": "cf_r2_create_bucket",
-      "description": "Create a new R2 bucket. Write — gated by confirm.",
+      "description": "Create a new R2 bucket. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -581,7 +581,7 @@
     },
     {
       "name": "cf_r2_delete_bucket",
-      "description": "Delete an R2 bucket. Destructive — double-gated.",
+      "description": "Delete an R2 bucket. Destructive \u2014 double-gated.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -592,7 +592,7 @@
     },
     {
       "name": "cf_cache_purge",
-      "description": "Purge Cloudflare cache by URL, tag, host, prefix, or everything. Destructive — gated by confirm.",
+      "description": "Purge Cloudflare cache by URL, tag, host, prefix, or everything. Destructive \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -606,36 +606,36 @@
   "repository": "https://github.com/groupthink-dev/cloudflare-blade-mcp",
   "highlights": [
     {
-      "icon": "🌐",
-      "text": "DNS — zones, records, bulk import/export across all your domains"
+      "icon": "\ud83c\udf10",
+      "text": "DNS \u2014 zones, records, bulk import/export across all your domains"
     },
     {
-      "icon": "⚙️",
-      "text": "Workers — scripts, deployments, settings, bindings, versions, secrets, cron schedules"
+      "icon": "\u2699\ufe0f",
+      "text": "Workers \u2014 scripts, deployments, settings, bindings, versions, secrets, cron schedules"
     },
     {
-      "icon": "📄",
-      "text": "Pages — projects, builds, rollback, domains, cache purge"
+      "icon": "\ud83d\udcc4",
+      "text": "Pages \u2014 projects, builds, rollback, domains, cache purge"
     },
     {
-      "icon": "🪣",
-      "text": "R2 — bucket lifecycle, location hints, storage classes"
+      "icon": "\ud83e\udea3",
+      "text": "R2 \u2014 bucket lifecycle, location hints, storage classes"
     },
     {
-      "icon": "🔑",
-      "text": "KV — namespace provisioning, key-value CRUD, bulk operations"
+      "icon": "\ud83d\udd11",
+      "text": "KV \u2014 namespace provisioning, key-value CRUD, bulk operations"
     },
     {
-      "icon": "🗃️",
-      "text": "D1 — database provisioning, tables, queries, schema inspection, export"
+      "icon": "\ud83d\uddc3\ufe0f",
+      "text": "D1 \u2014 database provisioning, tables, queries, schema inspection, export"
     },
     {
-      "icon": "🧭",
-      "text": "Vectorize — index lifecycle and metadata-index management"
+      "icon": "\ud83e\udded",
+      "text": "Vectorize \u2014 index lifecycle and metadata-index management"
     },
     {
-      "icon": "✨",
-      "text": "AI — AI Search, AI Gateway observability, and Workers AI inference"
+      "icon": "\u2728",
+      "text": "AI \u2014 AI Search, AI Gateway observability, and Workers AI inference"
     }
   ],
   "links": [
@@ -664,7 +664,7 @@
       "url": "https://developers.cloudflare.com/workers-ai/"
     }
   ],
-  "readme": "### What it does\n\nCloudflare Edge Platform gives your AI agent operational control over Cloudflare infrastructure — DNS records, Workers, Pages, R2, KV, D1, Tunnels, Vectorize, AI Search, AI Gateway, Workers AI, and cache — through 78 purpose-built tools.\n\nYour agent can check DNS propagation, provision KV/D1 storage, wire Worker bindings, inspect Vectorize indexes, query AI Search, review AI Gateway logs, run Workers AI diagnostics, roll back a broken Pages deploy, rotate a Workers secret, query a D1 database, and purge cache in a single conversation. No context switching between dashboards.\n\n### Token efficiency\n\nCloudflare API responses are large and noisy. Raw responses waste context window on pagination metadata, empty fields, and internal IDs your agent will never use.\n\nEach tool includes a **concise formatter** that extracts only the fields that matter. A typical `list_zones` call returns ~200 tokens instead of ~800. Across a session with dozens of API calls, this saves thousands of tokens and keeps your agent focused.\n\n### Safety model\n\nThe plugin follows a read-free, write-gated pattern:\n\n- **Reads** work immediately — list zones, get records, inspect deployments, review AI Gateway logs\n- **Writes** require `confirm: true` — create records, put secrets, provision KV/D1/Vectorize resources, run Workers AI inference\n- **Destructive operations** are double-gated where practical — delete namespaces/databases/indexes require explicit confirmation and exact-name checks\n\nThis means your agent can explore your infrastructure freely but must be explicit about changes. Accidental deletions are structurally prevented.\n\n### Domain coverage\n\n| Domain | Tools | What you can do |\n|--------|-------|-----------------|\n| DNS | 10 | Zones, records, bulk create/update, BIND export |\n| Workers | 13 | Scripts, settings, bindings, deployments, versions, secrets, cron triggers |\n| Pages | 7 | Projects, builds, rollback, custom domains, build cache |\n| R2 | 4 | Buckets with location hints, jurisdiction, storage class |\n| KV | 9 | Namespace provisioning, key CRUD, bulk put/delete |\n| D1 | 9 | Database provisioning, tables, SQL query/execute, schema, export |\n| Tunnels | 7 | Create, configure, connections, ingress routing |\n| Vectorize | 8 | Index lifecycle, operational info, metadata indexes |\n| AI | 10 | AI Search queries, AI Gateway CRUD/logs, Workers AI model search/run |\n| Cache | 1 | Purge by URL, tag, host, prefix, or everything |",
+  "readme": "### What it does\n\nCloudflare Edge Platform gives your AI agent operational control over Cloudflare infrastructure \u2014 DNS records, Workers, Pages, R2, KV, D1, Tunnels, Vectorize, AI Search, AI Gateway, Workers AI, and cache \u2014 through 78 purpose-built tools.\n\nYour agent can check DNS propagation, provision KV/D1 storage, wire Worker bindings, inspect Vectorize indexes, query AI Search, review AI Gateway logs, run Workers AI diagnostics, roll back a broken Pages deploy, rotate a Workers secret, query a D1 database, and purge cache in a single conversation. No context switching between dashboards.\n\n### Token efficiency\n\nCloudflare API responses are large and noisy. Raw responses waste context window on pagination metadata, empty fields, and internal IDs your agent will never use.\n\nEach tool includes a **concise formatter** that extracts only the fields that matter. A typical `list_zones` call returns ~200 tokens instead of ~800. Across a session with dozens of API calls, this saves thousands of tokens and keeps your agent focused.\n\n### Safety model\n\nThe plugin follows a read-free, write-gated pattern:\n\n- **Reads** work immediately \u2014 list zones, get records, inspect deployments, review AI Gateway logs\n- **Writes** require `confirm: true` \u2014 create records, put secrets, provision KV/D1/Vectorize resources, run Workers AI inference\n- **Destructive operations** are double-gated where practical \u2014 delete namespaces/databases/indexes require explicit confirmation and exact-name checks\n\nThis means your agent can explore your infrastructure freely but must be explicit about changes. Accidental deletions are structurally prevented.\n\n### Domain coverage\n\n| Domain | Tools | What you can do |\n|--------|-------|-----------------|\n| DNS | 10 | Zones, records, bulk create/update, BIND export |\n| Workers | 13 | Scripts, settings, bindings, deployments, versions, secrets, cron triggers |\n| Pages | 7 | Projects, builds, rollback, custom domains, build cache |\n| R2 | 4 | Buckets with location hints, jurisdiction, storage class |\n| KV | 9 | Namespace provisioning, key CRUD, bulk put/delete |\n| D1 | 9 | Database provisioning, tables, SQL query/execute, schema, export |\n| Tunnels | 7 | Create, configure, connections, ingress routing |\n| Vectorize | 8 | Index lifecycle, operational info, metadata indexes |\n| AI | 10 | AI Search queries, AI Gateway CRUD/logs, Workers AI model search/run |\n| Cache | 1 | Purge by URL, tag, host, prefix, or everything |",
   "install": {
     "runtime": "node",
     "package": "cloudflare-blade-mcp",
@@ -678,7 +678,7 @@
     },
     {
       "name": "CLOUDFLARE_ACCOUNT_ID",
-      "description": "Cloudflare Account ID — required for account-level tools including KV, D1, Tunnels, Workers, Pages, R2, Vectorize, and AI",
+      "description": "Cloudflare Account ID \u2014 required for account-level tools including KV, D1, Tunnels, Workers, Pages, R2, Vectorize, and AI",
       "secret": false
     },
     {

--- a/plugins/tools/vultr-blade-mcp.json
+++ b/plugins/tools/vultr-blade-mcp.json
@@ -1,9 +1,9 @@
 {
   "name": "vultr-blade-mcp",
   "title": "Vultr GPU Cloud",
-  "description": "Manage Vultr GPU compute infrastructure — VMs, bare metal, serverless inference, DNS, firewall, snapshots, and billing. 50 tools implementing virtualisation-v1, serverless-v1, and dns-authoritative-v1 contracts.",
-  "tagline": "GPU compute infrastructure — VMs, bare metal, inference, DNS, firewall, snapshots, billing",
-  "version": "0.3.0",
+  "description": "Manage Vultr GPU compute infrastructure \u2014 VMs, bare metal, serverless inference, DNS, firewall, snapshots, and billing. 50 tools implementing virtualisation-v1, serverless-v1, and dns-authoritative-v1 contracts.",
+  "tagline": "GPU compute infrastructure \u2014 VMs, bare metal, inference, DNS, firewall, snapshots, billing",
+  "version": "0.4.0",
   "author": "groupthink-dev",
   "license": "MIT",
   "icon": "/icons/vultr-blade-mcp.svg",
@@ -21,20 +21,20 @@
   "multi_instance": false,
   "highlights": [
     {
-      "icon": "🖥️",
-      "text": "50 tools — VMs, bare metal, inference, DNS, firewall, snapshots, billing"
+      "icon": "\ud83d\udda5\ufe0f",
+      "text": "50 tools \u2014 VMs, bare metal, inference, DNS, firewall, snapshots, billing"
     },
     {
-      "icon": "⚡",
-      "text": "GPU-first — plans default to GPU type with VRAM and pricing"
+      "icon": "\u26a1",
+      "text": "GPU-first \u2014 plans default to GPU type with VRAM and pricing"
     },
     {
-      "icon": "🧠",
-      "text": "Serverless inference — manage subscriptions and track token usage"
+      "icon": "\ud83e\udde0",
+      "text": "Serverless inference \u2014 manage subscriptions and track token usage"
     },
     {
-      "icon": "🔒",
-      "text": "Dual write-gate — env var + per-call confirm for all 24 destructive ops"
+      "icon": "\ud83d\udd12",
+      "text": "Dual write-gate \u2014 env var + per-call confirm for all 24 destructive ops"
     }
   ],
   "links": [
@@ -55,7 +55,7 @@
       "url": "https://my.vultr.com/settings/#settingsapi"
     }
   ],
-  "readme": "### What it does\n\nVultr GPU Compute Infrastructure provides comprehensive control over Vultr's GPU-oriented services through 50 MCP tools. Provision VMs and bare metal, manage serverless inference, configure DNS and firewalls, take snapshots, and track billing — all from your AI agent.\n\n### Tool coverage\n\n| Domain | Tools | What you can do |\n|--------|-------|-----------------|\n| Instances | 11 | List, get, status, bandwidth, create, delete, start, stop, reboot, update, reverse DNS |\n| Bare Metal | 9 | List, get, bandwidth, plans, create, delete, start, stop, reboot |\n| Inference | 5 | List, get, create, delete subscriptions, track usage |\n| DNS | 5 | List domains, list/create/update/delete records |\n| Firewall | 6 | List/get/create/delete groups, list/create rules |\n| Snapshots | 4 | List, get, create, delete |\n| Scripts | 4 | List, get, create, delete startup scripts |\n| Reference | 4 | Plans (GPU specs + pricing), regions, OS images, SSH keys |\n| Account | 2 | Account info, billing history |\n\n### GPU provisioning flow\n\nList GPU plans (`type=vcg`), pick a region, select an OS image, inject cloud-init user_data (installs Docker + NVIDIA toolkit + pulls your OCI image), attach a firewall group and startup script, and create. Poll status until `server_status=ok`. Snapshot before teardown. Delete when done.\n\n### Token efficiency\n\nFormatters strip ~60% of Vultr's verbose API responses. Plans prominently display GPU specs (type, VRAM, count) and pricing. Inference API keys are masked. Responses are capped at 4000 characters with pagination guidance.\n\n### Safety\n\nAll 24 write operations require dual confirmation: `VULTR_WRITE_ENABLED=true` environment variable AND `confirm: true` per-call parameter. Creating instances and bare metal incurs compute charges immediately.",
+  "readme": "### What it does\n\nVultr GPU Compute Infrastructure provides comprehensive control over Vultr's GPU-oriented services through 50 MCP tools. Provision VMs and bare metal, manage serverless inference, configure DNS and firewalls, take snapshots, and track billing \u2014 all from your AI agent.\n\n### Tool coverage\n\n| Domain | Tools | What you can do |\n|--------|-------|-----------------|\n| Instances | 11 | List, get, status, bandwidth, create, delete, start, stop, reboot, update, reverse DNS |\n| Bare Metal | 9 | List, get, bandwidth, plans, create, delete, start, stop, reboot |\n| Inference | 5 | List, get, create, delete subscriptions, track usage |\n| DNS | 5 | List domains, list/create/update/delete records |\n| Firewall | 6 | List/get/create/delete groups, list/create rules |\n| Snapshots | 4 | List, get, create, delete |\n| Scripts | 4 | List, get, create, delete startup scripts |\n| Reference | 4 | Plans (GPU specs + pricing), regions, OS images, SSH keys |\n| Account | 2 | Account info, billing history |\n\n### GPU provisioning flow\n\nList GPU plans (`type=vcg`), pick a region, select an OS image, inject cloud-init user_data (installs Docker + NVIDIA toolkit + pulls your OCI image), attach a firewall group and startup script, and create. Poll status until `server_status=ok`. Snapshot before teardown. Delete when done.\n\n### Token efficiency\n\nFormatters strip ~60% of Vultr's verbose API responses. Plans prominently display GPU specs (type, VRAM, count) and pricing. Inference API keys are masked. Responses are capped at 4000 characters with pagination guidance.\n\n### Safety\n\nAll 24 write operations require dual confirmation: `VULTR_WRITE_ENABLED=true` environment variable AND `confirm: true` per-call parameter. Creating instances and bare metal incurs compute charges immediately.",
   "install": {
     "runtime": "npx",
     "package": "vultr-blade-mcp"
@@ -63,7 +63,7 @@
   "tools": [
     {
       "name": "vultr_account_info",
-      "description": "Get Vultr account info — email, name, balance, payment method.",
+      "description": "Get Vultr account info \u2014 email, name, balance, payment method.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "none",
@@ -74,24 +74,24 @@
     },
     {
       "name": "vultr_billing_history",
-      "description": "Recent billing history — invoices, charges, dates.",
+      "description": "Recent billing history \u2014 invoices, charges, dates. Emits `_meta` envelope disclosing date-range filter and cursor state.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
       "name": "vultr_vm_list",
-      "description": "List Vultr VM instances with server-side per_page/cursor + optional label/region/tag filters.",
+      "description": "List Vultr VM instances with server-side per_page/cursor + optional label/region/tag filters. Emits `_meta` envelope disclosing region/tag/label filters applied.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -107,7 +107,7 @@
     },
     {
       "name": "vultr_vm_status",
-      "description": "Lightweight VM status — power_status, server_status, main_ip.",
+      "description": "Lightweight VM status \u2014 power_status, server_status, main_ip.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
@@ -129,35 +129,35 @@
     },
     {
       "name": "vultr_vm_list_plans",
-      "description": "List available VM plans (CPU/RAM/storage, GPU types, regions).",
+      "description": "List available VM plans (CPU/RAM/storage, GPU types, regions). Emits `_meta` envelope disclosing no-filter applied + plan count.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
       "name": "vultr_vm_list_images",
-      "description": "List available OS images and ISO IDs.",
+      "description": "List available OS images and ISO IDs. Emits `_meta` envelope disclosing no-filter applied + image count.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
       "name": "vultr_vm_list_regions",
-      "description": "List available datacenter regions.",
+      "description": "List available datacenter regions. Emits `_meta` envelope disclosing region count.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -173,7 +173,7 @@
     },
     {
       "name": "vultr_vm_create",
-      "description": "Create a new VM instance. Write — gated by confirm.",
+      "description": "Create a new VM instance. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -184,7 +184,7 @@
     },
     {
       "name": "vultr_vm_delete",
-      "description": "Delete a VM instance. Destructive — gated by confirm.",
+      "description": "Delete a VM instance. Destructive \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -195,7 +195,7 @@
     },
     {
       "name": "vultr_vm_start",
-      "description": "Start a stopped VM. Write — gated by confirm.",
+      "description": "Start a stopped VM. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -206,7 +206,7 @@
     },
     {
       "name": "vultr_vm_stop",
-      "description": "Stop a running VM. Write — gated by confirm.",
+      "description": "Stop a running VM. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -217,7 +217,7 @@
     },
     {
       "name": "vultr_vm_reboot",
-      "description": "Reboot a VM. Write — gated by confirm.",
+      "description": "Reboot a VM. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -228,7 +228,7 @@
     },
     {
       "name": "vultr_vm_update",
-      "description": "Update VM label/tag/plan. Write — gated by confirm.",
+      "description": "Update VM label/tag/plan. Write \u2014 gated by confirm.",
       "risk_class": "reversible_write",
       "granularity": {
         "scope_filtering": "server-side",
@@ -239,7 +239,7 @@
     },
     {
       "name": "vultr_vm_set_reverse_dns",
-      "description": "Set reverse DNS for an IP. Write — gated by confirm.",
+      "description": "Set reverse DNS for an IP. Write \u2014 gated by confirm.",
       "risk_class": "reversible_write",
       "granularity": {
         "scope_filtering": "server-side",
@@ -250,13 +250,13 @@
     },
     {
       "name": "vultr_bm_list",
-      "description": "List bare metal instances with server-side per_page/cursor + optional label/region filters.",
+      "description": "List bare metal instances with server-side per_page/cursor + optional label/region filters. Emits `_meta` envelope disclosing filters applied.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -283,18 +283,18 @@
     },
     {
       "name": "vultr_bm_list_plans",
-      "description": "List available bare metal plans.",
+      "description": "List available bare metal plans. Emits `_meta` envelope disclosing plan count.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
       "name": "vultr_bm_create",
-      "description": "Provision a new bare metal instance. Write — gated by confirm.",
+      "description": "Provision a new bare metal instance. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -305,7 +305,7 @@
     },
     {
       "name": "vultr_bm_delete",
-      "description": "Delete a bare metal instance. Destructive — gated by confirm.",
+      "description": "Delete a bare metal instance. Destructive \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -316,7 +316,7 @@
     },
     {
       "name": "vultr_bm_start",
-      "description": "Start a stopped bare metal instance. Write — gated by confirm.",
+      "description": "Start a stopped bare metal instance. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -327,7 +327,7 @@
     },
     {
       "name": "vultr_bm_stop",
-      "description": "Stop a running bare metal instance. Write — gated by confirm.",
+      "description": "Stop a running bare metal instance. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -338,7 +338,7 @@
     },
     {
       "name": "vultr_bm_reboot",
-      "description": "Reboot a bare metal instance. Write — gated by confirm.",
+      "description": "Reboot a bare metal instance. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -349,29 +349,29 @@
     },
     {
       "name": "vultr_dns_list_domains",
-      "description": "List DNS domains managed by Vultr (server-side per_page/cursor).",
+      "description": "List DNS domains managed by Vultr (server-side per_page/cursor). Emits `_meta` envelope disclosing cursor state.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
       "name": "vultr_dns_list_records",
-      "description": "List DNS records for a domain (server-side domain + per_page/cursor).",
+      "description": "List DNS records for a domain (server-side domain + per_page/cursor). Emits `_meta` envelope disclosing domain scope.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
       "name": "vultr_dns_create_record",
-      "description": "Create a DNS record. Write — gated by confirm.",
+      "description": "Create a DNS record. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -382,7 +382,7 @@
     },
     {
       "name": "vultr_dns_update_record",
-      "description": "Update an existing DNS record. Write — gated by confirm.",
+      "description": "Update an existing DNS record. Write \u2014 gated by confirm.",
       "risk_class": "reversible_write",
       "granularity": {
         "scope_filtering": "server-side",
@@ -393,7 +393,7 @@
     },
     {
       "name": "vultr_dns_delete_record",
-      "description": "Delete a DNS record. Destructive — gated by confirm.",
+      "description": "Delete a DNS record. Destructive \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -404,13 +404,13 @@
     },
     {
       "name": "vultr_fw_list_groups",
-      "description": "List firewall groups (server-side per_page/cursor).",
+      "description": "List firewall groups (server-side per_page/cursor). Emits `_meta` envelope.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -426,7 +426,7 @@
     },
     {
       "name": "vultr_fw_create_group",
-      "description": "Create a firewall group. Write — gated by confirm.",
+      "description": "Create a firewall group. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -437,7 +437,7 @@
     },
     {
       "name": "vultr_fw_delete_group",
-      "description": "Delete a firewall group. Destructive — gated by confirm.",
+      "description": "Delete a firewall group. Destructive \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -448,18 +448,18 @@
     },
     {
       "name": "vultr_fw_list_rules",
-      "description": "List rules in a firewall group (server-side firewall_group_id + per_page/cursor).",
+      "description": "List rules in a firewall group (server-side firewall_group_id + per_page/cursor). Emits `_meta` envelope disclosing group scope.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
       "name": "vultr_fw_create_rule",
-      "description": "Create a firewall rule in a group. Write — gated by confirm.",
+      "description": "Create a firewall rule in a group. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -470,13 +470,13 @@
     },
     {
       "name": "vultr_script_list",
-      "description": "List startup scripts (server-side per_page/cursor + optional type filter).",
+      "description": "List startup scripts (server-side per_page/cursor + optional type filter). Emits `_meta` envelope.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -492,7 +492,7 @@
     },
     {
       "name": "vultr_script_create",
-      "description": "Create a startup script. Write — gated by confirm.",
+      "description": "Create a startup script. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -503,7 +503,7 @@
     },
     {
       "name": "vultr_script_delete",
-      "description": "Delete a startup script. Destructive — gated by confirm.",
+      "description": "Delete a startup script. Destructive \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -514,13 +514,13 @@
     },
     {
       "name": "vultr_snap_list",
-      "description": "List snapshots (server-side per_page/cursor + optional description filter).",
+      "description": "List snapshots (server-side per_page/cursor + optional description filter). Emits `_meta` envelope.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -536,7 +536,7 @@
     },
     {
       "name": "vultr_snap_create",
-      "description": "Create a snapshot from a VM. Write — gated by confirm.",
+      "description": "Create a snapshot from a VM. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -547,7 +547,7 @@
     },
     {
       "name": "vultr_snap_delete",
-      "description": "Delete a snapshot. Destructive — gated by confirm.",
+      "description": "Delete a snapshot. Destructive \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -558,13 +558,13 @@
     },
     {
       "name": "vultr_inference_list",
-      "description": "List inference (Serverless Inference) subscriptions (server-side per_page/cursor).",
+      "description": "List inference (Serverless Inference) subscriptions (server-side per_page/cursor). Emits `_meta` envelope.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -580,7 +580,7 @@
     },
     {
       "name": "vultr_inference_create",
-      "description": "Create an inference subscription. Write — gated by confirm.",
+      "description": "Create an inference subscription. Write \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -591,7 +591,7 @@
     },
     {
       "name": "vultr_inference_delete",
-      "description": "Delete an inference subscription. Destructive — gated by confirm.",
+      "description": "Delete an inference subscription. Destructive \u2014 gated by confirm.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -615,7 +615,7 @@
   "env": [
     {
       "name": "VULTR_API_KEY",
-      "description": "Vultr API key for authentication — all tools require this",
+      "description": "Vultr API key for authentication \u2014 all tools require this",
       "secret": true
     },
     {
@@ -630,7 +630,7 @@
     "icon": "cpu",
     "product": "Vultr",
     "setup_guide": "docs/setup-guide.md",
-    "blurb": "GPU compute infrastructure — 50 tools for VMs, bare metal, inference, DNS, firewall, snapshots, and billing across Vultr's global datacentres.",
+    "blurb": "GPU compute infrastructure \u2014 50 tools for VMs, bare metal, inference, DNS, firewall, snapshots, and billing across Vultr's global datacentres.",
     "help_text": "Create an API key at my.vultr.com/settings/#settingsapi. The key provides access to your Vultr account including creating instances (which incur compute charges).",
     "help_url": "https://www.vultr.com/api/",
     "fields": [
@@ -638,7 +638,7 @@
         "key": "VULTR_API_KEY",
         "label": "API Key",
         "secret": true,
-        "placeholder": "Create at my.vultr.com → Settings → API",
+        "placeholder": "Create at my.vultr.com \u2192 Settings \u2192 API",
         "required": true,
         "help": "Full-access API key. Instance creation incurs GPU compute charges immediately."
       }
@@ -685,7 +685,7 @@
       "shared_services": [
         "virtualisation"
       ],
-      "label": "Cost audit — find idle instances",
+      "label": "Cost audit \u2014 find idle instances",
       "body": "List all instances, check their power status and cost, identify stopped instances still incurring charges, and delete any that are no longer needed."
     },
     {


### PR DESCRIPTION
## Summary

Catalog-side companion to the two TS-language blade PRs in DD-338 Phase C Wave 3 (Cloud+Mail cohort — TS half). Sister Python pair (`fastmail-blade-mcp` + `gmail-blade-mcp`) lands in a separate stallari-plugins PR.

Flips `audit_surface: minimal -> structured` on **23 read tools** across two blades:

**`cloudflare-blade-mcp` (9 flips, catalog version 0.3.0 → 0.4.0):**
- B set (7): cf_d1_query, cf_d1_list_tables, cf_d1_describe_table, cf_tunnel_list_configs, cf_tunnel_list_connections, cf_workers_list_secrets, cf_pages_list_domains
- C set (2): cf_dns_export_records, cf_d1_export
- `cf_d1_query` keeps `deterministic_ordering: unstable` (DD-338 B.1.b PRIMARY architect lock)

**`vultr-blade-mcp` (14 flips, catalog version 0.3.0 → 0.4.0):**
- B set (10): vultr_billing_history, vultr_vm_list, vultr_bm_list, vultr_dns_list_domains, vultr_dns_list_records, vultr_fw_list_groups, vultr_fw_list_rules, vultr_script_list, vultr_snap_list, vultr_inference_list
- C set (4): vultr_vm_list_plans, vultr_vm_list_images, vultr_vm_list_regions, vultr_bm_list_plans
- `vultr_vm_ssh_keys` intentionally NOT promoted (OQ-2 — stays `minimal` as user-owned personal data)

Each promoted tool description gets a one-line `_meta` envelope disclosure appended.

## Cross-repo PRs (must merge first)

- https://github.com/Groupthink-dev/cloudflare-blade-mcp/pull/1 — `feat/dd-338-c-w3 -> 0.4.0` (9-tool envelope emission + helper + tests)
- https://github.com/Groupthink-dev/vultr-blade-mcp/pull/1 — `feat/dd-338-c-w3 -> 0.4.0` (14-tool envelope emission + helper + tests + first server tests)

## Test plan

- [x] `node scripts/build-catalog.js` — green (70 entries / 37 services, no AJV errors)
- [x] `npm test` — 164/164 pass + 14 skipped (no regressions)
- [x] `cf_d1_query.deterministic_ordering` confirmed unchanged at `unstable`
- [x] `vultr_vm_ssh_keys.audit_surface` confirmed unchanged at `minimal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)