### PR TITLE
DD-338 Phase C Wave 5 Python catalog flips — apple-messages + apple-reminders

### DIFF
--- a/plugins/tools/apple-messages-blade-mcp.json
+++ b/plugins/tools/apple-messages-blade-mcp.json
@@ -3,7 +3,7 @@
   "title": "Apple Messages",
   "description": "Apple Messages (iMessage) operations — conversations, search, contacts, attachments, send",
   "tagline": "Read, search, and send via iMessage on macOS",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": "groupthink-dev",
   "license": "MIT",
   "icon": "/icons/apple-messages-blade-mcp.svg",
@@ -49,7 +49,7 @@
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -71,7 +71,7 @@
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -82,7 +82,7 @@
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -93,7 +93,7 @@
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -104,7 +104,7 @@
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -126,7 +126,7 @@
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {

--- a/plugins/tools/apple-reminders-blade-mcp.json
+++ b/plugins/tools/apple-reminders-blade-mcp.json
@@ -3,7 +3,7 @@
   "title": "Apple Reminders",
   "description": "Apple Reminders operations — lists, reminders, search, due dates, create, complete, update, delete",
   "tagline": "Native Apple Reminders access on macOS",
-  "version": "0.1.2",
+  "version": "0.3.0",
   "author": "groupthink-dev",
   "license": "MIT",
   "tier": "certified",
@@ -55,7 +55,7 @@
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -77,7 +77,7 @@
         "scope_filtering": "client-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -88,7 +88,7 @@
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {


### PR DESCRIPTION
## Summary

Catalog-side flip for the DD-338 Phase C Wave 5 Python sub-cohort: 9 multi-record read tools across two Apple Python blade-mcps move `granularity.audit_surface: minimal → structured`.

### apple-messages-blade-mcp (0.1.1 → 0.2.0)
- `messages_chats` · `messages_messages` · `messages_recent` · `messages_search` · `messages_contacts` · `messages_attachments`

### apple-reminders-blade-mcp (0.1.2 → 0.3.0)
- `reminders_items` · `reminders_search` · `reminders_due`

### Held at minimal
- `messages_unread` and `reminders_lists` stay at `audit_surface: minimal` per OQ-5 PRIMARY lock (already-fully-returned personal data; no filter; trivial envelope adds zero contract value).

### scope_filtering preserved
`reminders_search` keeps `scope_filtering: client-side` per Phase 0 divergence #1 — AppleScript enumerates all reminders then filters by title substring (genuine over-fetch).

## Test plan
- [x] `python -c "json.load(open(...))"` — both files parse
- [x] `jsonschema.validate` against `schemas/catalog-entry.schema.json` — VALID
- [ ] CI catalog build (downstream)

## Related
- Spec: `2026-05-23-dd-338-c-w5-apple-python.md`
- Substrate PR: Groupthink-dev/apple-messages-blade-mcp#1
- Substrate PR: Groupthink-dev/apple-reminders-blade-mcp#1

🤖 Generated with [Claude Code](https://claude.com/claude-code)