### PR TITLE
DD-338 Phase C Wave 4 catalog flips — mastodon + things3

### DIFF
--- a/plugins/tools/mastodon-blade-mcp.json
+++ b/plugins/tools/mastodon-blade-mcp.json
@@ -1,9 +1,9 @@
 {
   "name": "mastodon-blade-mcp",
   "title": "Mastodon",
-  "description": "Mastodon operations \u2014 timelines, statuses, notifications, search, interactions, multi-instance",
+  "description": "Mastodon operations — timelines, statuses, notifications, search, interactions, multi-instance",
   "tagline": "Browse, post, and interact across the fediverse",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": "groupthink-dev",
   "license": "MIT",
   "icon": "/icons/mastodon-blade-mcp.svg",
@@ -20,7 +20,7 @@
   "tools": [
     {
       "name": "mastodon_info",
-      "description": "Health check \u2014 instance URL, account, write gate status.",
+      "description": "Health check — instance URL, account, write gate status.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "none",
@@ -42,7 +42,7 @@
     },
     {
       "name": "mastodon_timeline_home",
-      "description": "Home timeline \u2014 accounts you follow. Cursor pagination. Accepts scope=public|personal|family|work mapped to Mastodon lists via MASTODON_*_LIST_ID env vars.",
+      "description": "Home timeline — accounts you follow. Cursor pagination. Accepts scope=public|personal|family|work mapped to Mastodon lists via MASTODON_*_LIST_ID env vars.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
@@ -59,7 +59,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -70,7 +70,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -81,7 +81,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -92,7 +92,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -114,7 +114,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -141,7 +141,7 @@
     },
     {
       "name": "mastodon_account_statuses",
-      "description": "Statuses authored by an account. Accepts scope=public|personal|family|work as a membership precondition \u2014 refuses if account_id is outside the scope's list.",
+      "description": "Statuses authored by an account. Accepts scope=public|personal|family|work as a membership precondition — refuses if account_id is outside the scope's list.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
@@ -158,7 +158,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -169,7 +169,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -180,12 +180,12 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
       "name": "mastodon_notifications",
-      "description": "Recent notifications \u2014 mentions, follows, boosts, favourites. Accepts scope=public|personal|family|work to filter to actors in the scope's list.",
+      "description": "Recent notifications — mentions, follows, boosts, favourites. Accepts scope=public|personal|family|work to filter to actors in the scope's list.",
       "risk_class": "read_only",
       "granularity": {
         "scope_filtering": "server-side",
@@ -202,7 +202,7 @@
         "scope_filtering": "none",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -213,7 +213,7 @@
         "scope_filtering": "none",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -224,7 +224,7 @@
         "scope_filtering": "none",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -268,7 +268,7 @@
         "scope_filtering": "server-side",
         "field_projection": "none",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -295,7 +295,7 @@
     },
     {
       "name": "mastodon_post",
-      "description": "Post a new status. Write \u2014 gated.",
+      "description": "Post a new status. Write — gated.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "none",
@@ -306,7 +306,7 @@
     },
     {
       "name": "mastodon_reply",
-      "description": "Reply to a status. Write \u2014 gated.",
+      "description": "Reply to a status. Write — gated.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -317,7 +317,7 @@
     },
     {
       "name": "mastodon_edit",
-      "description": "Edit an existing status. Write \u2014 gated.",
+      "description": "Edit an existing status. Write — gated.",
       "risk_class": "reversible_write",
       "granularity": {
         "scope_filtering": "server-side",
@@ -328,7 +328,7 @@
     },
     {
       "name": "mastodon_delete",
-      "description": "Delete a status. Destructive \u2014 gated.",
+      "description": "Delete a status. Destructive — gated.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -449,7 +449,7 @@
     },
     {
       "name": "mastodon_block",
-      "description": "Block an account. Reversible write \u2014 destructive social impact.",
+      "description": "Block an account. Reversible write — destructive social impact.",
       "risk_class": "external_side_effect",
       "granularity": {
         "scope_filtering": "server-side",
@@ -535,7 +535,7 @@
     },
     {
       "name": "MASTODON_PERSONAL_LIST_ID",
-      "description": "Mastodon list ID mapped to scope=personal. Per-instance form: MASTODON_PERSONAL_LIST_ID_<INSTANCE>. Leave unset \u2192 scope=personal degrades to passthrough.",
+      "description": "Mastodon list ID mapped to scope=personal. Per-instance form: MASTODON_PERSONAL_LIST_ID_<INSTANCE>. Leave unset → scope=personal degrades to passthrough.",
       "default": ""
     },
     {
@@ -601,28 +601,28 @@
   },
   "highlights": [
     {
-      "icon": "\ud83d\udce8",
-      "text": "Timelines \u2014 home, local, federated, hashtag, and list feeds"
+      "icon": "📨",
+      "text": "Timelines — home, local, federated, hashtag, and list feeds"
     },
     {
-      "icon": "\ud83d\udd0d",
-      "text": "Search \u2014 accounts, statuses, and hashtags across the fediverse"
+      "icon": "🔍",
+      "text": "Search — accounts, statuses, and hashtags across the fediverse"
     },
     {
-      "icon": "\ud83d\udd14",
-      "text": "Notifications \u2014 mentions, boosts, favourites, follow requests"
+      "icon": "🔔",
+      "text": "Notifications — mentions, boosts, favourites, follow requests"
     },
     {
-      "icon": "\u270d\ufe0f",
-      "text": "Compose \u2014 post, reply, boost, favourite, bookmark"
+      "icon": "✍️",
+      "text": "Compose — post, reply, boost, favourite, bookmark"
     },
     {
-      "icon": "\ud83c\udf10",
-      "text": "Multi-instance \u2014 manage multiple accounts from one server"
+      "icon": "🌐",
+      "text": "Multi-instance — manage multiple accounts from one server"
     },
     {
-      "icon": "\ud83d\udd12",
-      "text": "Write-gated \u2014 posting disabled by default, explicit opt-in"
+      "icon": "🔒",
+      "text": "Write-gated — posting disabled by default, explicit opt-in"
     }
   ],
   "links": [
@@ -643,7 +643,7 @@
       "url": "https://docs.joinmastodon.org/api/oauth-scopes/"
     }
   ],
-  "readme": "### What it does\n\nMastodon Blade MCP gives your AI agent access to the Mastodon social network \u2014 reading timelines, searching content, managing notifications, and composing posts. It works with any Mastodon-compatible instance (Mastodon, Pleroma, GoToSocial, Akkoma) through the standard Mastodon API.\n\nYour agent can catch up on your home timeline, search for discussions on a topic, check notifications, and draft or publish posts \u2014 all from a single conversation.\n\n### Multi-instance support\n\nConfigure multiple accounts across different instances using `MASTODON_PROVIDERS`. Each provider gets its own instance URL and token, and your agent can switch between them within a session. Useful for managing personal and project accounts separately.\n\n### Safety model\n\nAll write operations (posting, replying, boosting, favouriting, following) are disabled by default:\n\n- **Read-only by default** \u2014 timelines, search, and notifications work immediately\n- **Write gate** \u2014 set `MASTODON_WRITE_ENABLED=true` to unlock posting and interactions\n- **Confirm gate** \u2014 each write tool requires `confirm: true` per call\n\nThis prevents accidental posts or follows while still allowing full read access for monitoring and research.",
+  "readme": "### What it does\n\nMastodon Blade MCP gives your AI agent access to the Mastodon social network — reading timelines, searching content, managing notifications, and composing posts. It works with any Mastodon-compatible instance (Mastodon, Pleroma, GoToSocial, Akkoma) through the standard Mastodon API.\n\nYour agent can catch up on your home timeline, search for discussions on a topic, check notifications, and draft or publish posts — all from a single conversation.\n\n### Multi-instance support\n\nConfigure multiple accounts across different instances using `MASTODON_PROVIDERS`. Each provider gets its own instance URL and token, and your agent can switch between them within a session. Useful for managing personal and project accounts separately.\n\n### Safety model\n\nAll write operations (posting, replying, boosting, favouriting, following) are disabled by default:\n\n- **Read-only by default** — timelines, search, and notifications work immediately\n- **Write gate** — set `MASTODON_WRITE_ENABLED=true` to unlock posting and interactions\n- **Confirm gate** — each write tool requires `confirm: true` per call\n\nThis prevents accidental posts or follows while still allowing full read access for monitoring and research.",
   "scenarios": [
     {
       "type": "workflow",

--- a/plugins/tools/things3-blade-mcp.json
+++ b/plugins/tools/things3-blade-mcp.json
@@ -1,9 +1,9 @@
 {
   "name": "things3-blade-mcp",
   "title": "Things 3",
-  "description": "Things 3 task management via AppleScript and URL scheme \u2014 macOS only",
+  "description": "Things 3 task management via AppleScript and URL scheme — macOS only",
   "tagline": "GTD task management through Things 3 on macOS",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": "groupthink-dev",
   "license": "MIT",
   "icon": "/icons/things3-blade-mcp.svg",
@@ -113,7 +113,7 @@
         "scope_filtering": "client-side",
         "field_projection": "none",
         "deterministic_ordering": "unstable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -124,7 +124,7 @@
         "scope_filtering": "client-side",
         "field_projection": "none",
         "deterministic_ordering": "unstable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -135,7 +135,7 @@
         "scope_filtering": "client-side",
         "field_projection": "none",
         "deterministic_ordering": "unstable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -146,7 +146,7 @@
         "scope_filtering": "client-side",
         "field_projection": "none",
         "deterministic_ordering": "unstable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -212,7 +212,7 @@
         "scope_filtering": "client-side",
         "field_projection": "none",
         "deterministic_ordering": "unstable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -223,7 +223,7 @@
         "scope_filtering": "client-side",
         "field_projection": "none",
         "deterministic_ordering": "unstable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -353,8 +353,8 @@
     "complexity": "trivial",
     "icon": "checkmark.circle.fill",
     "product": "Things 3",
-    "blurb": "Connect to Things 3 for GTD task management \u2014 inbox, today, projects, areas, tags, and task creation via AppleScript and URL scheme.",
-    "help_text": "Things 3 must be installed from the Mac App Store. No API keys required \u2014 access is via AppleScript and the Things URL scheme.",
+    "blurb": "Connect to Things 3 for GTD task management — inbox, today, projects, areas, tags, and task creation via AppleScript and URL scheme.",
+    "help_text": "Things 3 must be installed from the Mac App Store. No API keys required — access is via AppleScript and the Things URL scheme.",
     "prerequisites": [
       "macOS with Things 3 installed",
       "AppleScript permission for terminal (auto-prompted on first use)"
@@ -371,33 +371,33 @@
     ],
     "test": {
       "skip": true,
-      "skip_reason": "AppleScript-only access to Things 3 \u2014 no HTTP surface."
+      "skip_reason": "AppleScript-only access to Things 3 — no HTTP surface."
     }
   },
   "highlights": [
     {
-      "icon": "\ud83d\udce5",
-      "text": "Inbox \u2014 capture and triage tasks in the Things inbox"
+      "icon": "📥",
+      "text": "Inbox — capture and triage tasks in the Things inbox"
     },
     {
-      "icon": "\u2b50",
-      "text": "Today \u2014 view and manage today\u2019s focused task list"
+      "icon": "⭐",
+      "text": "Today — view and manage today’s focused task list"
     },
     {
-      "icon": "\ud83d\udcc1",
-      "text": "Projects \u2014 browse projects, areas, headings, and checklists"
+      "icon": "📁",
+      "text": "Projects — browse projects, areas, headings, and checklists"
     },
     {
-      "icon": "\ud83c\udff7\ufe0f",
-      "text": "Tags \u2014 filter and organise tasks by tag"
+      "icon": "🏷️",
+      "text": "Tags — filter and organise tasks by tag"
     },
     {
-      "icon": "\u2795",
-      "text": "Create \u2014 add tasks with dates, tags, projects, checklists"
+      "icon": "➕",
+      "text": "Create — add tasks with dates, tags, projects, checklists"
     },
     {
-      "icon": "\ud83d\udd04",
-      "text": "Sync \u2014 changes sync to Things Cloud on all devices"
+      "icon": "🔄",
+      "text": "Sync — changes sync to Things Cloud on all devices"
     }
   ],
   "links": [
@@ -418,7 +418,7 @@
       "url": "https://culturedcode.com/things/support/articles/2803572/"
     }
   ],
-  "readme": "### What it does\n\nThings 3 gives your AI agent access to Cultured Code\u2019s GTD task manager on macOS. Browse your inbox, today list, upcoming and someday tasks, projects, areas, and tags \u2014 and create new tasks with full metadata.\n\nYour agent can review what\u2019s due today, capture new tasks into the inbox, create structured projects with headings and checklists, and search across your entire task database.\n\n### macOS integration\n\nThis plugin uses two native interfaces: AppleScript for reading Things\u2019 database, and the Things URL scheme for creating and modifying tasks. No API keys, no cloud configuration \u2014 just Things 3 installed on your Mac.\n\nChanges sync automatically via Things Cloud to your iPhone, iPad, and other Macs.\n\n### Safety model\n\nRead operations (inbox, today, projects, areas, tags, search) work immediately.\n\nTask creation uses the Things URL scheme, which opens Things briefly to process the command. This is a native macOS interaction \u2014 no network requests involved.\n\n### GTD workflow support\n\n| View | What you can do |\n|------|-----------------|\n| Inbox | Browse and triage uncategorised captures |\n| Today | See today\u2019s focused list |\n| Upcoming | Review scheduled tasks with dates |\n| Someday | Browse deferred items |\n| Projects | Navigate project hierarchies with headings |\n| Areas | Browse areas of responsibility |\n| Tags | Filter tasks by any tag |\n| Logbook | Review completed tasks |",
+  "readme": "### What it does\n\nThings 3 gives your AI agent access to Cultured Code’s GTD task manager on macOS. Browse your inbox, today list, upcoming and someday tasks, projects, areas, and tags — and create new tasks with full metadata.\n\nYour agent can review what’s due today, capture new tasks into the inbox, create structured projects with headings and checklists, and search across your entire task database.\n\n### macOS integration\n\nThis plugin uses two native interfaces: AppleScript for reading Things’ database, and the Things URL scheme for creating and modifying tasks. No API keys, no cloud configuration — just Things 3 installed on your Mac.\n\nChanges sync automatically via Things Cloud to your iPhone, iPad, and other Macs.\n\n### Safety model\n\nRead operations (inbox, today, projects, areas, tags, search) work immediately.\n\nTask creation uses the Things URL scheme, which opens Things briefly to process the command. This is a native macOS interaction — no network requests involved.\n\n### GTD workflow support\n\n| View | What you can do |\n|------|-----------------|\n| Inbox | Browse and triage uncategorised captures |\n| Today | See today’s focused list |\n| Upcoming | Review scheduled tasks with dates |\n| Someday | Browse deferred items |\n| Projects | Navigate project hierarchies with headings |\n| Areas | Browse areas of responsibility |\n| Tags | Filter tasks by any tag |\n| Logbook | Review completed tasks |",
   "scenarios": [
     {
       "type": "workflow",
@@ -426,7 +426,7 @@
       "target_type": "plugin",
       "shared_services": [],
       "label": "Morning task triage",
-      "body": "Review the Things inbox for uncategorised captures, move items to appropriate projects with due dates and tags, then check today\u2019s list to confirm priorities."
+      "body": "Review the Things inbox for uncategorised captures, move items to appropriate projects with due dates and tags, then check today’s list to confirm priorities."
     },
     {
       "type": "workflow",


### PR DESCRIPTION
## Summary

DD-338 Phase C Wave 4 catalog half — flips `audit_surface: minimal → structured` on the 18 tools promoted by the companion blade PRs.

**Mastodon (12 flips):**
- `mastodon_timeline_public`, `mastodon_timeline_local`, `mastodon_timeline_hashtag`, `mastodon_timeline_list`
- `mastodon_context`, `mastodon_relationships`
- `mastodon_followers`, `mastodon_following`, `mastodon_list_accounts`
- `mastodon_trending_tags`, `mastodon_trending_statuses`, `mastodon_trending_links`

**Things3 (6 flips):**
- `get_random_inbox`, `get_random_today`, `get_random_anytime`, `get_random_todos`
- `search_todos`, `search_advanced`

**Catalog version bumps:** mastodon 0.1.1 → 0.2.0; things3 0.1.1 → 0.2.0.

**OQ-1 / OQ-3 collapse-to-A (no flip):** 5 mastodon personal-data trivial-envelope tools (`bookmarks`, `favourites`, `lists`, `conversations`, `filters`) and 15 things3 list-read tools (`get_inbox`, `get_today`, `get_upcoming`, `get_anytime`, `get_someday`, `get_logbook`, `get_trash`, `get_deadlines`, `get_todos`, `get_projects`, `get_areas`, `get_tags`, `get_tagged_items`, `get_recent`, `json_export`) stay at `audit_surface: minimal` per OQ-5 PRIMARY (audit-doc 2026-05-23). Trivial envelopes on already-fully-returned personal-data enumerations add zero contract value.

**Other granularity declarations unchanged:**
- Mastodon W4 tools — `deterministic_ordering: stable` (B.1.b sort calls already in place; OQ-6 adds 2 sort calls in the blade PR so `context` + `relationships` declarations become honest).
- Things3 W4 tools — `deterministic_ordering: unstable` per DD-338 plan §"Out of phasing — Things3 SQLite-direct rewrite" (envelope adds the filter-disclosure dimension orthogonally; payload ordering remains honestly unstable).

**Sibling PRs:**
- mastodon-blade-mcp: `feat/dd-338-c-w4` (12 tools wrapped)
- things3-blade-mcp: `feat/dd-338-c-w4` (6 tools wrapped)

## Test plan

- [x] `npm ci && node scripts/build-catalog.js` succeeds (59 plugins + 11 packs = 70 entries)
- [ ] Architect review: confirm `audit_surface: structured` shipped end-to-end in companion blade PRs before merging this catalog half (don't merge catalog ahead of blade — would temporarily declare a contract the blades don't yet honour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)