### PR TITLE
DD-338 Phase C Wave 5 Swift catalog flips — apple-mail + apple-notes + SemVer re-align

### DIFF
--- a/plugins/tools/apple-mail-blade-mcp.json
+++ b/plugins/tools/apple-mail-blade-mcp.json
@@ -6,7 +6,7 @@
   "title": "Apple Mail",
   "description": "On-disk Apple Mail reader — Envelope Index SQLite + .emlx bodies + attachments. Read-only; never opens the network. NLTagger entity extraction under the deterministic-extraction carve-out (DD-240).",
   "tagline": "Tens of GB of personal correspondence, on-device, no network",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "author": "groupthink-dev",
   "license": "MIT",
   "icon": "/icons/apple-mail-blade-mcp.svg",
@@ -30,7 +30,7 @@
         "scope_filtering": "none",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -41,7 +41,7 @@
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -52,7 +52,7 @@
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -63,7 +63,7 @@
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -107,7 +107,7 @@
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {

--- a/plugins/tools/apple-notes-blade-mcp.json
+++ b/plugins/tools/apple-notes-blade-mcp.json
@@ -3,7 +3,7 @@
   "title": "Apple Notes",
   "description": "On-disk Apple Notes reader — NoteStore.sqlite + protobuf body decode + folder hierarchy. Read-only; never opens the network. Library form factor (DD-240 Phase A) — compiled into Stallari.",
   "tagline": "Years of notes, on-device, no iCloud round-trip",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "groupthink-dev",
   "license": "MIT",
   "icon": "/icons/apple-notes-blade-mcp.svg",
@@ -27,7 +27,7 @@
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -38,7 +38,7 @@
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -49,7 +49,7 @@
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {


### PR DESCRIPTION
8 `audit_surface` flips minimal → structured: apple-mail 5 + apple-notes 3.

## SemVer re-align (OQ-8)
- `apple-mail-blade-mcp.json`: 0.1.0 → 0.3.0 (matches blade Version.swift 0.3.0)
- `apple-notes-blade-mcp.json`: 0.1.0 → 0.2.0 (matches blade Version.swift 0.2.0)

DEVFU `2026-05-23-catalog-version-blade-semver-sweep` filed for sweep across other blades.

Spec: `specs/2026-05-23-dd-338-c-w5-apple-swift.md`