### PR TITLE
DD-338 Phase C W5 — stallari-blade-mcp catalog audit_surface flip (8 tools)

### DIFF
--- a/plugins/tools/stallari-blade-mcp.json
+++ b/plugins/tools/stallari-blade-mcp.json
@@ -5,7 +5,7 @@
   ],
   "title": "Stallari Vault",
   "description": "Obsidian vault operations via Swift MCP — read, write, search, properties, graph analysis, lens semantic tools",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": "groupthink-dev",
   "license": "MIT",
   "icon": "/icons/stallari-blade-mcp.svg",
@@ -100,7 +100,7 @@
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -133,7 +133,7 @@
         "scope_filtering": "none",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -199,7 +199,7 @@
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -210,7 +210,7 @@
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -287,7 +287,7 @@
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -342,7 +342,7 @@
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -419,7 +419,7 @@
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {
@@ -430,7 +430,7 @@
         "scope_filtering": "server-side",
         "field_projection": "top-level",
         "deterministic_ordering": "stable",
-        "audit_surface": "minimal"
+        "audit_surface": "structured"
       }
     },
     {


### PR DESCRIPTION
## Summary

Catalog sister-PR to [stallari-vault PR #2](https://github.com/Groupthink-dev/stallari-vault/pull/2) (DD-338 Phase C W5 Cluster WB).

Flip `audit_surface: minimal → structured` for 8 stallari-blade-mcp tools whose Swift code now emits the canonical `_meta: {...}` audit envelope per the DD-287 assembler regex contract.

**Tools flipped (8):**

- `vault_files`
- `vault_recents`
- `vault_search`
- `vault_search_context`
- `vault_tag`
- `vault_tasks`
- `vault_links`
- `vault_backlinks`

**Catalog top-level version:** `0.5.0 → 0.6.0`.

The other 7 catalog-already-structured tools served by Swift code (`vault_query_properties`, `vault_context_prepare`/`expand`/`sources`, `vault_orphans`, `vault_deadends`, `vault_lens_status`) need no catalog change — the stallari-vault PR brings the code into compliance with the existing declaration (closes the catalog/code drift surfaced by DD-338 Phase 0 audit 2026-05-24; DD-333 Phase C harness is mock-mode-v1 so this drift wasn't fail-CI).

## Test plan

- [x] `git diff` is exactly 9 lines (8 audit_surface flips + 1 version bump).
- [x] JSON file remains valid (`python3 -c "import json; json.load(open('plugins/tools/stallari-blade-mcp.json'))"`).
- [ ] Land alongside [stallari-vault PR #2](https://github.com/Groupthink-dev/stallari-vault/pull/2) — order doesn't matter (the catalog declaration is the contract; emission is what the harness verifies at conformance-harness run).

Refs: [[DD-338]] Phase C Wave 5, DD-287 audit envelope, DD-333 Phase C conformance harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)